### PR TITLE
feat(docker): Improve Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # Build the manager binary
-FROM golang:1.19 as builder
+FROM docker.io/library/golang:1.19.9@sha256:9613596d7405705447f36440a59a3a2a1d22384c7568ae1838d0129964c5ba13 as builder
 ARG TARGETOS
 ARG TARGETARCH
 ARG PACKAGE=github.com/padok-team/burrito
@@ -31,9 +31,9 @@ RUN CGO_ENABLED=0 GOOS=${TARGETOS:-linux} GOARCH=${TARGETARCH} go build -a \
           -X ${PACKAGE}/internal/version.Version=${VERSION} \
           -X ${PACKAGE}/internal/version.CommitHash=${COMMIT_HASH} \
           -X ${PACKAGE}/internal/version.BuildTimestamp=${BUILD_TIMESTAMP}" \
-        -o bin/burrito main.go 
+        -o bin/burrito main.go
 
-FROM golang:alpine
+FROM docker.io/library/alpine:3.18.0@sha256:02bb6f428431fbc2809c5d1b41eab5a68350194fb508869a33cb1af4444c9b11
 
 RUN apk add --update git bash openssh
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -35,7 +35,7 @@ RUN CGO_ENABLED=0 GOOS=${TARGETOS:-linux} GOARCH=${TARGETARCH} go build -a \
 
 FROM docker.io/library/alpine:3.18.0@sha256:02bb6f428431fbc2809c5d1b41eab5a68350194fb508869a33cb1af4444c9b11
 
-RUN apk add --update git bash openssh
+RUN apk add --update --no-cache git bash openssh
 
 WORKDIR /
 COPY --from=builder /workspace/bin/burrito .


### PR DESCRIPTION
# Features

## Use fixed versions in `FROM` statements

Fixes #84.

https://github.com/padok-team/burrito/blob/f2156f542f1e7cdbadb70c2c0b9c64750f35a783/Dockerfile#L2

https://github.com/padok-team/burrito/blob/f2156f542f1e7cdbadb70c2c0b9c64750f35a783/Dockerfile#L36

### Note

The SHA256 digests are the ones of the multi-platform image's manifest, obtained with the two followings commands as of May 14th, 2023:

```
docker buildx imagetools inspect golang:1.19.9
docker buildx imagetools inspect alpine:3.18.0
```

This enables the Docker image to be built with these fixed versions on any platform supported by the referenced manifests.

## Reduce Docker image size

Fixes #124.

By using `alpine:3.18.0` instead of `golang:alpine`, the size decreases from ~390MB to ~96MB.

Adding the `--no-cache` option reduces the image only by ~1.5MB but is common practice.

Now the final image has a size of **~95MB**.

### Note

The size described are for the `linux/arm64/v8` architecture, I did not tested on `linux/amd64`, but the gains should be similar.