### PR TITLE
fix(lints): fix code smell detected by golangci-lint

### DIFF
--- a/internal/controllers/manager.go
+++ b/internal/controllers/manager.go
@@ -44,8 +44,6 @@ var (
 	scheme = runtime.NewScheme()
 )
 
-const ()
-
 type Controllers struct {
 	config *config.Config
 }

--- a/internal/controllers/terraformpullrequest/comment/default.go
+++ b/internal/controllers/terraformpullrequest/comment/default.go
@@ -66,6 +66,9 @@ func (c *DefaultComment) Generate(commit string) (string, error) {
 		Layers: reportedLayers,
 	}
 	comment := bytes.NewBufferString("")
-	defaultTemplate.Execute(comment, data)
+	err := defaultTemplate.Execute(comment, data)
+	if err != nil {
+		return "", err
+	}
 	return comment.String(), nil
 }

--- a/internal/controllers/terraformpullrequest/github/provider.go
+++ b/internal/controllers/terraformpullrequest/github/provider.go
@@ -21,13 +21,7 @@ type Github struct {
 }
 
 func (g *Github) IsConfigPresent(c *config.Config) bool {
-	if &c.Controller.GithubConfig == nil {
-		return false
-	}
-	if c.Controller.GithubConfig.APIToken == "" {
-		return false
-	}
-	return true
+	return c.Controller.GithubConfig.APIToken != ""
 }
 
 func (g *Github) Init(c *config.Config) error {

--- a/internal/controllers/terraformpullrequest/gitlab/provider.go
+++ b/internal/controllers/terraformpullrequest/gitlab/provider.go
@@ -18,13 +18,7 @@ type Gitlab struct {
 }
 
 func (g *Gitlab) IsConfigPresent(c *config.Config) bool {
-	if &c.Controller.GitlabConfig == nil {
-		return false
-	}
-	if c.Controller.GitlabConfig.APIToken == "" {
-		return false
-	}
-	return true
+	return c.Controller.GitlabConfig.APIToken != ""
 }
 
 func (g *Gitlab) Init(c *config.Config) error {

--- a/internal/webhook/github/provider_test.go
+++ b/internal/webhook/github/provider_test.go
@@ -7,7 +7,7 @@ import (
 	"encoding/hex"
 	"encoding/json"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"os"
 
 	"net/http"
@@ -42,7 +42,7 @@ func TestGithub_GetEvent_PushEvent(t *testing.T) {
 	}
 	defer payloadFile.Close()
 
-	payloadBytes, err := ioutil.ReadAll(payloadFile)
+	payloadBytes, err := io.ReadAll(payloadFile)
 	if err != nil {
 		t.Fatalf("failed to read payload file: %v", err)
 	}
@@ -99,7 +99,7 @@ func TestGithub_GetEvent_PullRequestEvent(t *testing.T) {
 	}
 	defer payloadFile.Close()
 
-	payloadBytes, err := ioutil.ReadAll(payloadFile)
+	payloadBytes, err := io.ReadAll(payloadFile)
 	if err != nil {
 		t.Fatalf("failed to read payload file: %v", err)
 	}

--- a/internal/webhook/gitlab/provider_test.go
+++ b/internal/webhook/gitlab/provider_test.go
@@ -3,7 +3,7 @@ package gitlab_test
 import (
 	"bytes"
 	"encoding/json"
-	"io/ioutil"
+	"io"
 	"os"
 
 	"net/http"
@@ -38,7 +38,7 @@ func TestGitlab_GetEvent_PushEvent(t *testing.T) {
 	}
 	defer payloadFile.Close()
 
-	payloadBytes, err := ioutil.ReadAll(payloadFile)
+	payloadBytes, err := io.ReadAll(payloadFile)
 	if err != nil {
 		t.Fatalf("failed to read payload file: %v", err)
 	}
@@ -90,7 +90,7 @@ func TestGitlab_GetEvent_MergeRequestEvent(t *testing.T) {
 	}
 	defer payloadFile.Close()
 
-	payloadBytes, err := ioutil.ReadAll(payloadFile)
+	payloadBytes, err := io.ReadAll(payloadFile)
 	if err != nil {
 		t.Fatalf("failed to read payload file: %v", err)
 	}


### PR DESCRIPTION
From the code smells detected by [golangci-lint](https://golangci-lint.run/).

See PR #157 for CI/CD integration.

If fixes the following lint warnings:

```
internal/burrito/config/config.go:126:14: Error return value of `v.BindPFlags` is not checked (errcheck)
        v.BindPFlags(flags)
                    ^
internal/burrito/config/config.go:154:13: Error return value of `v.BindEnv` is not checked (errcheck)
                        v.BindEnv(strings.Join(append(parts, tv), "."))
                                 ^
internal/controllers/terraformpullrequest/comment/default.go:69:25: Error return value of `defaultTemplate.Execute` is not checked (errcheck)
        defaultTemplate.Execute(comment, data)
                               ^
internal/testing/loading.go:40:18: Error return value of `filepath.WalkDir` is not checked (errcheck)
        filepath.WalkDir(path, func(path string, d fs.DirEntry, err error) error {
                        ^
internal/testing/loading.go:47:3: SA4009(related information): assignment to err (staticcheck)
                data, err := os.ReadFile(path)
                ^
internal/webhook/github/provider_test.go:10:2: SA1019: "io/ioutil" has been deprecated since Go 1.19: As of Go 1.16, the same functionality is now provided by package io or package os, and those implementations should be preferred in new code. See the specific function documentation for details. (staticcheck)
        "io/ioutil"
        ^
internal/webhook/gitlab/provider_test.go:6:2: SA1019: "io/ioutil" has been deprecated since Go 1.19: As of Go 1.16, the same functionality is now provided by package io or package os, and those implementations should be preferred in new code. See the specific function documentation for details. (staticcheck)
        "io/ioutil"
        ^
internal/controllers/terraformpullrequest/github/provider.go:24:5: SA4022: the address of a variable cannot be nil (staticcheck)
        if &c.Controller.GithubConfig == nil {
           ^
internal/controllers/terraformpullrequest/gitlab/provider.go:21:5: SA4022: the address of a variable cannot be nil (staticcheck)
        if &c.Controller.GitlabConfig == nil {
           ^
```