### PR TITLE
fix(rbac): update roles in plain manifests

### DIFF
--- a/manifests/base/controllers/clusterrole.yaml
+++ b/manifests/base/controllers/clusterrole.yaml
@@ -7,14 +7,24 @@ metadata:
     app.kubernetes.io/name: burrito-controllers
     app.kubernetes.io/part-of: burrito
 rules:
-  - apiGroups: ["events.k8s.io"]
-    resources: ["events"]
-    verbs: ["create", "update"]
-  - apiGroups: [""]
-    resources: ["events"]
-    verbs: ["create", "update"]
-  - apiGroups: [""]
-    resources: ["pods"]
+  - apiGroups:
+      - events.k8s.io
+    resources:
+      - events
+    verbs:
+      - create
+      - update
+  - apiGroups:
+      - ""
+    resources:
+      - events
+    verbs:
+      - create
+      - update
+  - apiGroups:
+      - ""
+    resources:
+      - pods
     verbs:
       - create
       - delete
@@ -30,6 +40,7 @@ rules:
     verbs:
       - create
       - delete
+      - deletecollection
       - get
       - list
       - patch
@@ -128,7 +139,7 @@ rules:
       - patch
       - update
   - apiGroups:
-      - "coordination.k8s.io"
+      - coordination.k8s.io
     resources:
       - leases
     verbs:

--- a/manifests/base/runner/clusterrole.yaml
+++ b/manifests/base/runner/clusterrole.yaml
@@ -1,0 +1,29 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  labels:
+    app.kubernetes.io/component: runner
+    app.kubernetes.io/name: burrito-runner
+    app.kubernetes.io/part-of: burrito
+  name: burrito-runner
+rules:
+  - apiGroups:
+      - coordination.k8s.io
+    resources:
+      - leases
+    verbs:
+      - get
+      - delete
+  - apiGroups:
+      - config.terraform.padok.cloud
+    resources:
+      - terraformlayers
+    verbs:
+      - get
+      - patch
+  - apiGroups:
+      - config.terraform.padok.cloud
+    resources:
+      - terraformrepositories
+    verbs:
+      - get

--- a/manifests/base/runner/clusterrolebinding.yaml
+++ b/manifests/base/runner/clusterrolebinding.yaml
@@ -9,7 +9,7 @@ metadata:
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
-  name: burrito-controllers
+  name: burrito-runner
 subjects:
   - kind: ServiceAccount
     name: burrito-runner

--- a/manifests/base/runner/kustomization.yaml
+++ b/manifests/base/runner/kustomization.yaml
@@ -3,4 +3,5 @@ kind: Kustomization
 
 resources:
   - serviceaccount.yaml
+  - clusterrole.yaml
   - clusterrolebinding.yaml

--- a/manifests/base/server/clusterrole.yaml
+++ b/manifests/base/server/clusterrole.yaml
@@ -11,7 +11,18 @@ rules:
       - config.terraform.padok.cloud
     resources:
       - terraformlayers
-      - terraformpullrequests
+    verbs:
+      - create
+      - delete
+      - get
+      - list
+      - patch
+      - update
+      - watch
+  - apiGroups:
+      - config.terraform.padok.cloud
+    resources:
+      - terraformrepositories
     verbs:
       - create
       - delete
@@ -29,15 +40,7 @@ rules:
   - apiGroups:
       - config.terraform.padok.cloud
     resources:
-      - terraformlayers/status
-    verbs:
-      - get
-      - patch
-      - update
-  - apiGroups:
-      - config.terraform.padok.cloud
-    resources:
-      - terraformrepositories
+      - terraformpullrequests
     verbs:
       - create
       - delete
@@ -49,26 +52,40 @@ rules:
   - apiGroups:
       - config.terraform.padok.cloud
     resources:
-      - terraformrepositories/finalizers
+      - terraformpullrequests/finalizers
     verbs:
       - update
   - apiGroups:
       - config.terraform.padok.cloud
     resources:
-      - terraformrepositories/status
+      - terraformpullrequests/status
     verbs:
       - get
       - patch
       - update
   - apiGroups:
-      - "coordination.k8s.io"
+      - config.terraform.padok.cloud
     resources:
-      - leases
+      - terraformruns
     verbs:
+      - create
+      - delete
       - get
       - list
-      - watch
-      - create
-      - update
       - patch
-      - delete
+      - update
+      - watch
+  - apiGroups:
+      - config.terraform.padok.cloud
+    resources:
+      - terraformruns/finalizers
+    verbs:
+      - update
+  - apiGroups:
+      - config.terraform.padok.cloud
+    resources:
+      - terraformruns/status
+    verbs:
+      - get
+      - patch
+      - update

--- a/manifests/crds/config.terraform.padok.cloud_terraformlayers.yaml
+++ b/manifests/crds/config.terraform.padok.cloud_terraformlayers.yaml
@@ -3,8 +3,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.11.2
-  creationTimestamp: null
+    controller-gen.kubebuilder.io/version: v0.11.4
   name: terraformlayers.config.terraform.padok.cloud
 spec:
   group: config.terraform.padok.cloud

--- a/manifests/crds/config.terraform.padok.cloud_terraformpullrequests.yaml
+++ b/manifests/crds/config.terraform.padok.cloud_terraformpullrequests.yaml
@@ -3,8 +3,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.11.2
-  creationTimestamp: null
+    controller-gen.kubebuilder.io/version: v0.11.4
   name: terraformpullrequests.config.terraform.padok.cloud
 spec:
   group: config.terraform.padok.cloud

--- a/manifests/crds/config.terraform.padok.cloud_terraformrepositories.yaml
+++ b/manifests/crds/config.terraform.padok.cloud_terraformrepositories.yaml
@@ -3,8 +3,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.11.2
-  creationTimestamp: null
+    controller-gen.kubebuilder.io/version: v0.11.4
   name: terraformrepositories.config.terraform.padok.cloud
 spec:
   group: config.terraform.padok.cloud

--- a/manifests/crds/config.terraform.padok.cloud_terraformruns.yaml
+++ b/manifests/crds/config.terraform.padok.cloud_terraformruns.yaml
@@ -3,8 +3,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.11.2
-  creationTimestamp: null
+    controller-gen.kubebuilder.io/version: v0.11.4
   name: terraformruns.config.terraform.padok.cloud
 spec:
   group: config.terraform.padok.cloud

--- a/manifests/install.yaml
+++ b/manifests/install.yaml
@@ -3,8 +3,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.11.2
-  creationTimestamp: null
+    controller-gen.kubebuilder.io/version: v0.11.4
   name: terraformlayers.config.terraform.padok.cloud
 spec:
   group: config.terraform.padok.cloud
@@ -1336,8 +1335,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.11.2
-  creationTimestamp: null
+    controller-gen.kubebuilder.io/version: v0.11.4
   name: terraformpullrequests.config.terraform.padok.cloud
 spec:
   group: config.terraform.padok.cloud
@@ -1460,8 +1458,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.11.2
-  creationTimestamp: null
+    controller-gen.kubebuilder.io/version: v0.11.4
   name: terraformrepositories.config.terraform.padok.cloud
 spec:
   group: config.terraform.padok.cloud
@@ -2774,8 +2771,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.11.2
-  creationTimestamp: null
+    controller-gen.kubebuilder.io/version: v0.11.4
   name: terraformruns.config.terraform.padok.cloud
 spec:
   group: config.terraform.padok.cloud
@@ -2971,6 +2967,7 @@ rules:
   verbs:
   - create
   - delete
+  - deletecollection
   - get
   - list
   - patch
@@ -3085,6 +3082,36 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
   labels:
+    app.kubernetes.io/component: runner
+    app.kubernetes.io/name: burrito-runner
+    app.kubernetes.io/part-of: burrito
+  name: burrito-runner
+rules:
+- apiGroups:
+  - coordination.k8s.io
+  resources:
+  - leases
+  verbs:
+  - get
+  - delete
+- apiGroups:
+  - config.terraform.padok.cloud
+  resources:
+  - terraformlayers
+  verbs:
+  - get
+  - patch
+- apiGroups:
+  - config.terraform.padok.cloud
+  resources:
+  - terraformrepositories
+  verbs:
+  - get
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  labels:
     app.kubernetes.io/component: server
     app.kubernetes.io/name: burrito-server
     app.kubernetes.io/part-of: burrito
@@ -3094,7 +3121,18 @@ rules:
   - config.terraform.padok.cloud
   resources:
   - terraformlayers
-  - terraformpullrequests
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - config.terraform.padok.cloud
+  resources:
+  - terraformrepositories
   verbs:
   - create
   - delete
@@ -3112,15 +3150,7 @@ rules:
 - apiGroups:
   - config.terraform.padok.cloud
   resources:
-  - terraformlayers/status
-  verbs:
-  - get
-  - patch
-  - update
-- apiGroups:
-  - config.terraform.padok.cloud
-  resources:
-  - terraformrepositories
+  - terraformpullrequests
   verbs:
   - create
   - delete
@@ -3132,29 +3162,43 @@ rules:
 - apiGroups:
   - config.terraform.padok.cloud
   resources:
-  - terraformrepositories/finalizers
+  - terraformpullrequests/finalizers
   verbs:
   - update
 - apiGroups:
   - config.terraform.padok.cloud
   resources:
-  - terraformrepositories/status
+  - terraformpullrequests/status
   verbs:
   - get
   - patch
   - update
 - apiGroups:
-  - coordination.k8s.io
+  - config.terraform.padok.cloud
   resources:
-  - leases
+  - terraformruns
   verbs:
+  - create
+  - delete
   - get
   - list
-  - watch
-  - create
-  - update
   - patch
-  - delete
+  - update
+  - watch
+- apiGroups:
+  - config.terraform.padok.cloud
+  resources:
+  - terraformruns/finalizers
+  verbs:
+  - update
+- apiGroups:
+  - config.terraform.padok.cloud
+  resources:
+  - terraformruns/status
+  verbs:
+  - get
+  - patch
+  - update
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
@@ -3201,7 +3245,7 @@ metadata:
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
-  name: burrito-controllers
+  name: burrito-runner
 subjects:
 - kind: ServiceAccount
   name: burrito-runner


### PR DESCRIPTION
This PR updates the ClusterRoles used in the plain manifests by keeping them up to date with the Helm chart.