### PR TITLE
fix(server): Remove unused api call to repository on layer state get

### DIFF
--- a/internal/server/api/layers.go
+++ b/internal/server/api/layers.go
@@ -62,15 +62,6 @@ func (a *API) LayersHandler(c echo.Context) error {
 }
 
 func (a *API) getLayerState(layer configv1alpha1.TerraformLayer) string {
-	repository := &configv1alpha1.TerraformRepository{}
-	err := a.Client.Get(context.Background(), client.ObjectKey{
-		Namespace: layer.Spec.Repository.Namespace,
-		Name:      layer.Spec.Repository.Name,
-	}, repository)
-	if err != nil {
-		log.Errorf("could not get terraform repository: %s", err)
-		return "Unknown"
-	}
 	state := "success"
 	switch {
 	case len(layer.Status.Conditions) == 0:


### PR DESCRIPTION
This removes an unecessary API call that makes the server's LayersHandler very slow (1 api call is made per layer when listing layers). This drastically improves UI performances.