### PR TITLE
refactor(ui): rework input and dropdown without text wrapping

### DIFF
--- a/ui/src/components/inputs/Dropdown.tsx
+++ b/ui/src/components/inputs/Dropdown.tsx
@@ -90,6 +90,7 @@ const Dropdown: React.FC<DropdownProps> = ({
         rounded-lg
         text-base
         font-medium
+        whitespace-nowrap
         cursor-pointer
         outline-primary-600
         outline-offset-0

--- a/ui/src/components/inputs/Input.tsx
+++ b/ui/src/components/inputs/Input.tsx
@@ -74,12 +74,13 @@ const Input: React.FC<InputProps> = ({
       className={twMerge(
         `font-normal
         text-base
+        w-full
         ${variant === "light" ? "text-nuances-black" : "text-nuances-50"}`,
         disabled && "text-nuances-300"
       )}
     >
       {label}
-      <div className="relative flex items-center">
+      <div className="relative flex items-center justify-center w-full">
         {leftIcon && (
           <div
             className={twMerge(
@@ -96,8 +97,7 @@ const Input: React.FC<InputProps> = ({
         )}
         <input
           className={twMerge(
-            `w-[300px]
-            my-1
+            `my-1
             px-4
             py-2
             h-10

--- a/ui/src/pages/layers/components/RepositoriesDropdown.tsx
+++ b/ui/src/pages/layers/components/RepositoriesDropdown.tsx
@@ -71,6 +71,7 @@ const RepositoriesDropdown: React.FC<RepositoriesDropdownProps> = ({
       />
       <Input
         variant={variant}
+        className="w-full mx-2"
         placeholder="Search repositories"
         value={search}
         onChange={handleSearch}

--- a/ui/src/pages/layers/components/RepositoriesDropdown.tsx
+++ b/ui/src/pages/layers/components/RepositoriesDropdown.tsx
@@ -71,7 +71,6 @@ const RepositoriesDropdown: React.FC<RepositoriesDropdownProps> = ({
       />
       <Input
         variant={variant}
-        className="w-[200px] mx-2"
         placeholder="Search repositories"
         value={search}
         onChange={handleSearch}

--- a/ui/src/pages/login/Login.tsx
+++ b/ui/src/pages/login/Login.tsx
@@ -29,8 +29,8 @@ const Login: React.FC = () => {
         `}
       >
         <div className="flex items-center justify-center">
-          <div className="flex flex-col items-start justify-center min-w-[300px] gap-10">
-            <div className="flex flex-col items-start gap-2">
+          <div className="flex flex-col items-start justify-center w-[300px] gap-10">
+            <div className="flex flex-col items-start gap-2 w-full">
               <Burrito height={64} width={64} />
               <span
                 className={`
@@ -46,22 +46,24 @@ const Login: React.FC = () => {
                 Welcome to Burrito
               </span>
             </div>
-            <div className="flex flex-col items-center justify-center gap-8">
+            <div className="flex flex-col items-center justify-center gap-8 w-full">
               <Input
-                className="min-w-full"
+                className="w-full"
                 variant={theme}
                 placeholder="Your email"
                 label="Email"
+                type="email"
               />
               <Input
-                className="min-w-full"
+                className="w-full"
                 variant={theme}
                 placeholder="Your password"
                 label="Password"
                 rightIcon={<EyeSlashIcon />}
+                type="password"
               />
               <Button
-                className="min-w-full"
+                className="w-full"
                 variant={theme === "light" ? "primary" : "secondary"}
                 onClick={() => navigate("/")}
               >
@@ -72,7 +74,7 @@ const Login: React.FC = () => {
                   flex
                   flex-row
                   items-center
-                  min-w-full
+                  w-full
                   gap-4
                   ${
                     theme === "light"
@@ -85,7 +87,7 @@ const Login: React.FC = () => {
                 <span>OR</span>
                 <hr className="w-full" />
               </div>
-              <div className="flex flex-col items-center justify-center min-w-full gap-4">
+              <div className="flex flex-col items-center justify-center w-full gap-4">
                 <SocialButton
                   className="w-full"
                   variant="github"
@@ -104,7 +106,7 @@ const Login: React.FC = () => {
                 flex-row
                 items-center
                 justify-center
-                min-w-full
+                w-full
                 gap-1
                 p-6
                 rounded-lg


### PR DESCRIPTION
I noticed ugly text wrapping in a dropdown while drafting PR #220. To fix this, I also needed to rework the input component which broke the login page because of bad CSS I wrote. It's also fixed now.