### PR TITLE
feat(runner): implement runner image configuration

### DIFF
--- a/cmd/runner/start.go
+++ b/cmd/runner/start.go
@@ -5,6 +5,7 @@ package runner
 
 import (
 	"github.com/padok-team/burrito/internal/burrito"
+	"github.com/padok-team/burrito/internal/version"
 	"github.com/spf13/cobra"
 )
 
@@ -21,5 +22,9 @@ func buildRunnerStartCmd(app *burrito.App) *cobra.Command {
 
 	cmd.Flags().StringVar(&app.Config.Runner.SSHKnownHostsConfigMapName, "ssh-known-hosts-cm-name", "burrito-ssh-known-hosts", "configmap name to get known hosts file from")
 	cmd.Flags().StringVar(&app.Config.Runner.RunnerBinaryPath, "runner-binary-path", "/runner/bin", "binary path where the runner can expect to find terraform or terragrunt binaries")
+	cmd.Flags().StringVar(&app.Config.Runner.Image.Repository, "image-repository", "ghcr.io/padok-team/burrito", "runner image repository")
+	cmd.Flags().StringVar(&app.Config.Runner.Image.Tag, "image-tag", version.Version, "runner image tag")
+	cmd.Flags().StringVar(&app.Config.Runner.Image.PullPolicy, "image-pull-policy", "Always", "runner image pull policy")
+
 	return cmd
 }

--- a/deploy/charts/burrito/values.yaml
+++ b/deploy/charts/burrito/values.yaml
@@ -69,6 +69,10 @@ config:
     # Burrito runners configuration
     runner:
       sshKnownHostsConfigMapName: burrito-ssh-known-hosts
+      image:
+        repository: ghcr.io/padok-team/burrito
+        # tag: "" # By default, use the controller build version
+        pullPolicy: Always
 
 redis:
   enabled: true

--- a/internal/burrito/config/config.go
+++ b/internal/burrito/config/config.go
@@ -82,6 +82,13 @@ type RunnerConfig struct {
 	Repository                 RepositoryConfig `mapstructure:"repository"`
 	SSHKnownHostsConfigMapName string           `mapstructure:"sshKnownHostsConfigMapName"`
 	RunnerBinaryPath           string           `mapstructure:"runnerBinaryPath"`
+	Image                      ImageConfig      `mapstructure:"image"`
+}
+
+type ImageConfig struct {
+	Repository string `mapstructure:"repository"`
+	Tag        string `mapstructure:"tag"`
+	PullPolicy string `mapstructure:"pullPolicy"`
 }
 
 type Layer struct {

--- a/internal/controllers/terraformrun/pod.go
+++ b/internal/controllers/terraformrun/pod.go
@@ -6,7 +6,6 @@ import (
 
 	configv1alpha1 "github.com/padok-team/burrito/api/v1alpha1"
 	"github.com/padok-team/burrito/internal/burrito/config"
-	"github.com/padok-team/burrito/internal/version"
 	log "github.com/sirupsen/logrus"
 	corev1 "k8s.io/api/core/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
@@ -245,9 +244,10 @@ func defaultPodSpec(config *config.Config, layer *configv1alpha1.TerraformLayer,
 		ServiceAccountName: "burrito-runner",
 		Containers: []corev1.Container{
 			{
-				Name:  "runner",
-				Image: fmt.Sprintf("ghcr.io/padok-team/burrito:%s", version.Version),
-				Args:  []string{"runner", "start"},
+				Name:            "runner",
+				Image:           fmt.Sprintf("%s:%s", config.Runner.Image.Repository, config.Runner.Image.Tag),
+				ImagePullPolicy: corev1.PullPolicy(config.Runner.Image.PullPolicy),
+				Args:            []string{"runner", "start"},
 				VolumeMounts: []corev1.VolumeMount{
 					{
 						MountPath: "/home/burrito/.ssh/known_hosts",


### PR DESCRIPTION
The runner pods currently rely on a hardcoded image, with the only override option being through the overrideRunnerSpec parameter within TerraformLayers and TerraformRepositories custom resources. 

This pull request introduces the ability to specify the runner image directly within the configuration. This grants users the freedom to define a global default repository, tag and pull policy for the runner image