### PR TITLE
feat(controllers): add logging with k8s events

### DIFF
--- a/deploy/charts/burrito/templates/rbac.yaml
+++ b/deploy/charts/burrito/templates/rbac.yaml
@@ -143,6 +143,7 @@ rules:
   verbs:
   - create
   - update
+  - patch
 - apiGroups:
   - ""
   resources:

--- a/internal/controllers/manager.go
+++ b/internal/controllers/manager.go
@@ -92,36 +92,40 @@ func (c *Controllers) Exec() {
 		switch ctrlType {
 		case "layer":
 			if err = (&terraformlayer.Reconciler{
-				Client:  mgr.GetClient(),
-				Scheme:  mgr.GetScheme(),
-				Config:  c.config,
-				Storage: redis.New(c.config.Redis),
+				Client:   mgr.GetClient(),
+				Scheme:   mgr.GetScheme(),
+				Config:   c.config,
+				Recorder: mgr.GetEventRecorderFor("Burrito"),
+				Storage:  redis.New(c.config.Redis),
 			}).SetupWithManager(mgr); err != nil {
 				log.Fatalf("unable to create layer controller: %s", err)
 			}
 			log.Infof("layer controller started successfully")
 		case "repository":
 			if err = (&terraformrepository.Reconciler{
-				Client: mgr.GetClient(),
-				Scheme: mgr.GetScheme(),
+				Client:   mgr.GetClient(),
+				Scheme:   mgr.GetScheme(),
+				Recorder: mgr.GetEventRecorderFor("Burrito"),
 			}).SetupWithManager(mgr); err != nil {
 				log.Fatalf("unable to create repository controller: %s", err)
 			}
 			log.Infof("repository controller started successfully")
 		case "run":
 			if err = (&terraformrun.Reconciler{
-				Client: mgr.GetClient(),
-				Scheme: mgr.GetScheme(),
-				Config: c.config,
+				Client:   mgr.GetClient(),
+				Scheme:   mgr.GetScheme(),
+				Recorder: mgr.GetEventRecorderFor("Burrito"),
+				Config:   c.config,
 			}).SetupWithManager(mgr); err != nil {
 				log.Fatalf("unable to create run controller: %s", err)
 			}
 			log.Infof("run controller started successfully")
 		case "pullrequest":
 			if err = (&terraformpullrequest.Reconciler{
-				Client: mgr.GetClient(),
-				Scheme: mgr.GetScheme(),
-				Config: c.config,
+				Client:   mgr.GetClient(),
+				Scheme:   mgr.GetScheme(),
+				Recorder: mgr.GetEventRecorderFor("Burrito"),
+				Config:   c.config,
 			}).SetupWithManager(mgr); err != nil {
 				log.Fatalf("unable to create pullrequest controller: %s", err)
 			}

--- a/internal/controllers/terraformlayer/controller_test.go
+++ b/internal/controllers/terraformlayer/controller_test.go
@@ -15,11 +15,13 @@ import (
 	controller "github.com/padok-team/burrito/internal/controllers/terraformlayer"
 	storage "github.com/padok-team/burrito/internal/storage/mock"
 	utils "github.com/padok-team/burrito/internal/testing"
+	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/apimachinery/pkg/selection"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/client-go/kubernetes/scheme"
 	"k8s.io/client-go/rest"
+	"k8s.io/client-go/tools/record"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/envtest"
 	logf "sigs.k8s.io/controller-runtime/pkg/log"
@@ -73,6 +75,9 @@ var _ = BeforeSuite(func() {
 		Config:  config.TestConfig(),
 		Storage: storage.New(),
 		Clock:   &MockClock{},
+		Recorder: record.NewBroadcasterForTests(1*time.Second).NewRecorder(scheme.Scheme, corev1.EventSource{
+			Component: "burrito",
+		}),
 	}
 	Expect(err).NotTo(HaveOccurred())
 	Expect(k8sClient).NotTo(BeNil())

--- a/internal/controllers/terraformlayer/run.go
+++ b/internal/controllers/terraformlayer/run.go
@@ -8,6 +8,7 @@ import (
 
 	configv1alpha1 "github.com/padok-team/burrito/api/v1alpha1"
 	log "github.com/sirupsen/logrus"
+	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/apimachinery/pkg/selection"
@@ -144,6 +145,7 @@ func (r *Reconciler) cleanupRuns(ctx context.Context, layer *configv1alpha1.Terr
 		return err
 	}
 	log.Infof("deleted %d runs for layer %s", len(toDelete), layer.Name)
+	r.Recorder.Event(layer, corev1.EventTypeNormal, "Reconciliation", "Cleaned up old runs")
 	return nil
 }
 

--- a/internal/controllers/terraformlayer/states.go
+++ b/internal/controllers/terraformlayer/states.go
@@ -7,6 +7,7 @@ import (
 
 	configv1alpha1 "github.com/padok-team/burrito/api/v1alpha1"
 	log "github.com/sirupsen/logrus"
+	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	ctrl "sigs.k8s.io/controller-runtime"
 )
@@ -55,9 +56,11 @@ func (s *PlanNeeded) getHandler() Handler {
 		run := r.getRun(layer, repository, "plan")
 		err := r.Client.Create(ctx, &run)
 		if err != nil {
+			r.Recorder.Event(layer, corev1.EventTypeWarning, "Reconciliation", "Failed to create TerraformRun for Plan action")
 			log.Errorf("failed to create TerraformRun for Plan action on layer %s: %s", layer.Name, err)
 			return ctrl.Result{RequeueAfter: r.Config.Controller.Timers.OnError}, nil
 		}
+		r.Recorder.Event(layer, corev1.EventTypeNormal, "Reconciliation", "Created TerraformRun for Plan action")
 		return ctrl.Result{RequeueAfter: r.Config.Controller.Timers.WaitAction}, &run
 	}
 }
@@ -75,9 +78,11 @@ func (s *ApplyNeeded) getHandler() Handler {
 		run := r.getRun(layer, repository, "apply")
 		err := r.Client.Create(ctx, &run)
 		if err != nil {
+			r.Recorder.Event(layer, corev1.EventTypeWarning, "Reconciliation", "Failed to create TerraformRun for Apply action")
 			log.Errorf("failed to create TerraformRun for Apply action on layer %s: %s", layer.Name, err)
 			return ctrl.Result{RequeueAfter: r.Config.Controller.Timers.OnError}, nil
 		}
+		r.Recorder.Event(layer, corev1.EventTypeNormal, "Reconciliation", "Created TerraformRun for Apply action")
 		return ctrl.Result{RequeueAfter: r.Config.Controller.Timers.WaitAction}, &run
 	}
 }

--- a/internal/controllers/terraformpullrequest/controller_test.go
+++ b/internal/controllers/terraformpullrequest/controller_test.go
@@ -20,14 +20,17 @@ import (
 	"context"
 	"path/filepath"
 	"testing"
+	"time"
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 
+	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/client-go/kubernetes/scheme"
 	"k8s.io/client-go/rest"
+	"k8s.io/client-go/tools/record"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/envtest"
 	logf "sigs.k8s.io/controller-runtime/pkg/log"
@@ -108,6 +111,9 @@ var _ = BeforeSuite(func() {
 		Providers: []controller.Provider{
 			&provider.Mock{},
 		},
+		Recorder: record.NewBroadcasterForTests(1*time.Second).NewRecorder(scheme.Scheme, corev1.EventSource{
+			Component: "burrito",
+		}),
 	}
 	Expect(err).NotTo(HaveOccurred())
 	Expect(k8sClient).NotTo(BeNil())

--- a/internal/controllers/terraformpullrequest/layer.go
+++ b/internal/controllers/terraformpullrequest/layer.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 
+	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/apimachinery/pkg/selection"
@@ -29,6 +30,7 @@ func (r *Reconciler) getAffectedLayers(repository *configv1alpha1.TerraformRepos
 		}
 	}
 	if provider == nil {
+		r.Recorder.Event(pr, corev1.EventTypeWarning, "Provider error", "Could not find provider (gitlab, github...)")
 		return nil, fmt.Errorf("could not find provider for pull request %s", pr.Name)
 	}
 	changes, err := provider.GetChanges(repository, pr)

--- a/internal/controllers/terraformpullrequest/states.go
+++ b/internal/controllers/terraformpullrequest/states.go
@@ -2,11 +2,13 @@ package terraformpullrequest
 
 import (
 	"context"
+	"fmt"
 
 	configv1alpha1 "github.com/padok-team/burrito/api/v1alpha1"
 	"github.com/padok-team/burrito/internal/annotations"
 	"github.com/padok-team/burrito/internal/controllers/terraformpullrequest/comment"
 	log "github.com/sirupsen/logrus"
+	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	ctrl "sigs.k8s.io/controller-runtime"
 )
@@ -77,10 +79,12 @@ func planningHandler(ctx context.Context, r *Reconciler, repository *configv1alp
 func discoveryNeededHandler(ctx context.Context, r *Reconciler, repository *configv1alpha1.TerraformRepository, pr *configv1alpha1.TerraformPullRequest, state *State) ctrl.Result {
 	err := r.deleteTempLayers(ctx, pr)
 	if err != nil {
+		r.Recorder.Event(pr, corev1.EventTypeWarning, "Reconciliation", "Failed to delete temp layers for pull request")
 		log.Errorf("failed to delete temp layers for pull request %s: %s", pr.Name, err)
 	}
 	layers, err := r.getAffectedLayers(repository, pr)
 	if err != nil {
+		r.Recorder.Event(pr, corev1.EventTypeWarning, "Reconciliation", "Failed to get affected layers for pull request")
 		log.Errorf("failed to get affected layers for pull request %s: %s", pr.Name, err)
 		return ctrl.Result{RequeueAfter: r.Config.Controller.Timers.OnError}
 	}
@@ -89,8 +93,10 @@ func discoveryNeededHandler(ctx context.Context, r *Reconciler, repository *conf
 		err := r.Client.Create(ctx, &layer)
 		if err != nil {
 			log.Errorf("failed to create layer %s: %s", layer.Name, err)
+			r.Recorder.Event(pr, corev1.EventTypeWarning, "Reconciliation", "Failed to create layer for pull request")
 			return ctrl.Result{RequeueAfter: r.Config.Controller.Timers.OnError}
 		}
+		r.Recorder.Event(pr, corev1.EventTypeNormal, "Reconciliation", fmt.Sprintf("Created layer %s", layer.Name))
 	}
 	state.Status.LastDiscoveredCommit = pr.Annotations[annotations.LastBranchCommit]
 	return ctrl.Result{RequeueAfter: r.Config.Controller.Timers.WaitAction}
@@ -99,6 +105,7 @@ func discoveryNeededHandler(ctx context.Context, r *Reconciler, repository *conf
 func commentNeededHandler(ctx context.Context, r *Reconciler, repository *configv1alpha1.TerraformRepository, pr *configv1alpha1.TerraformPullRequest, state *State) ctrl.Result {
 	layers, err := GetLinkedLayers(r.Client, pr)
 	if err != nil {
+		r.Recorder.Event(pr, corev1.EventTypeWarning, "Reconciliation", "Failed to get linked layers for pull request")
 		log.Errorf("failed to get linked layers for pull request %s: %s", pr.Name, err)
 		return ctrl.Result{RequeueAfter: r.Config.Controller.Timers.OnError}
 	}
@@ -119,9 +126,11 @@ func commentNeededHandler(ctx context.Context, r *Reconciler, repository *config
 	comment := comment.NewDefaultComment(layers, r.Storage)
 	err = provider.Comment(repository, pr, comment)
 	if err != nil {
+		r.Recorder.Event(pr, corev1.EventTypeWarning, "Reconciliation", "Failed to comment pull request")
 		log.Errorf("an error occurred while commenting pull request: %s", err)
 		return ctrl.Result{RequeueAfter: r.Config.Controller.Timers.OnError}
 	}
+	r.Recorder.Event(pr, corev1.EventTypeNormal, "Reconciliation", "Commented pull request")
 	state.Status.LastCommentedCommit = pr.Annotations[annotations.LastBranchCommit]
 	return ctrl.Result{RequeueAfter: r.Config.Controller.Timers.WaitAction}
 }

--- a/internal/controllers/terraformrepository/controller.go
+++ b/internal/controllers/terraformrepository/controller.go
@@ -21,6 +21,7 @@ import (
 
 	log "github.com/sirupsen/logrus"
 	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/client-go/tools/record"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
@@ -30,7 +31,8 @@ import (
 // RepositoryReconciler reconciles a TerraformRepository object
 type Reconciler struct {
 	client.Client
-	Scheme *runtime.Scheme
+	Scheme   *runtime.Scheme
+	Recorder record.EventRecorder
 }
 
 //+kubebuilder:rbac:groups=config.terraform.padok.cloud,resources=terraformrepositories,verbs=get;list;watch;create;update;patch;delete

--- a/internal/controllers/terraformrun/controller_test.go
+++ b/internal/controllers/terraformrun/controller_test.go
@@ -19,6 +19,7 @@ import (
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/client-go/kubernetes/scheme"
 	"k8s.io/client-go/rest"
+	"k8s.io/client-go/tools/record"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/envtest"
 	logf "sigs.k8s.io/controller-runtime/pkg/log"
@@ -71,6 +72,9 @@ var _ = BeforeSuite(func() {
 		Scheme: scheme.Scheme,
 		Config: config.TestConfig(),
 		Clock:  &MockClock{},
+		Recorder: record.NewBroadcasterForTests(1*time.Second).NewRecorder(scheme.Scheme, corev1.EventSource{
+			Component: "burrito",
+		}),
 	}
 	Expect(err).NotTo(HaveOccurred())
 	Expect(k8sClient).NotTo(BeNil())


### PR DESCRIPTION
One of the main feedback from Burrito users was that it is quite difficult to debug as it is easy to  misconfigure something (tenants, serviceaccounts, cloud IAM...). This PR implements some logging from the controller using Kubernetes events. Hopefully this would make Burrito easier to install and to debug for users.

<img width="1168" alt="image" src="https://github.com/padok-team/burrito/assets/63159821/7d45f5b1-2e2f-4e45-bf9b-3bff7c13425b">
