### PR TITLE
feat(chart): update values & doc to get started easier

### DIFF
--- a/deploy/charts/burrito/README.md
+++ b/deploy/charts/burrito/README.md
@@ -1,0 +1,127 @@
+# burrito
+
+![Version: 0.4.1](https://img.shields.io/badge/Version-0.4.1-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: v0.4.1](https://img.shields.io/badge/AppVersion-v0.4.1-informational?style=flat-square)
+
+A Helm chart for handling a complete burrito deployment
+
+## Values
+
+| Key | Type | Default | Description |
+|-----|------|---------|-------------|
+| config.annotations | object | `{}` | Annotations to be added to the ConfigMap |
+| config.burrito.controller.githubConfig.apiToken | string | `""` | Github API token, prefer override with the BURRITO_CONTROLLER_GITHUBCONFIG_APITOKEN environment variable |
+| config.burrito.controller.githubConfig.appId | string | `""` | Github app ID, prefer override with the BURRITO_CONTROLLER_GITHUBCONFIG_APPID environment variable |
+| config.burrito.controller.githubConfig.installationId | string | `""` | Github app unstallation ID, prefer override with the BURRITO_CONTROLLER_GITHUBCONFIG_INSTALLATIONID environment variable |
+| config.burrito.controller.githubConfig.privateKey | string | `""` | Github app private key, prefer override with the BURRITO_CONTROLLER_GITHUBCONFIG_PRIVATEKEY environment variable |
+| config.burrito.controller.gitlabConfig.apiToken | string | `""` | Gitlab API token Prefer override with the BURRITO_CONTROLLER_GITLABCONFIG_APITOKEN environment variable |
+| config.burrito.controller.gitlabConfig.url | string | `""` | Gitlab URL |
+| config.burrito.controller.healthProbeBindAddress | string | `":8081"` | Adress to bind the controller health probe |
+| config.burrito.controller.kubernetesWebhookPort | int | `9443` | Port used to handle the Kubernetes webhook |
+| config.burrito.controller.leaderElection.enabled | bool | `true` | Enable/Disable leader election |
+| config.burrito.controller.leaderElection.id | string | `"6d185457.terraform.padok.cloud"` | Leader election lock name |
+| config.burrito.controller.maxConcurrentReconciles | int | `1` | Maximum number of concurrent reconciles for the controller, increse this value if you have a lot of resources to reconcile |
+| config.burrito.controller.metricsBindAddress | string | `":8080"` | Adress to bind the controller metrics |
+| config.burrito.controller.namespaces | list | `[]` | By default, the controller will only watch the tenants namespaces |
+| config.burrito.controller.terraformMaxRetries | int | `3` | Maximum number of retries for Terraform operations (plan, apply...) |
+| config.burrito.controller.timers.driftDetection | string | `"10m"` | Drift detection interval |
+| config.burrito.controller.timers.failureGracePeriod | int | `30` | Duration to wait before retrying on failure (increases exponentially with the amount of failed retries) |
+| config.burrito.controller.timers.onError | string | `"10s"` | Duration to wait before retrying on error |
+| config.burrito.controller.timers.waitAction | string | `"1m"` | Duration to wait before retrying on locked layer |
+| config.burrito.controller.types | list | `["layer","repository","run","pullrequest"]` | Resource types to watch for reconciliation |
+| config.burrito.datastore.addr | string | `":8080"` | Datastore exposed port |
+| config.burrito.datastore.serviceAccounts | list | `[]` | Service account to use for datastore operations (e.g. reading/writing to storage) |
+| config.burrito.datastore.storage.azure.container | string | `""` | Azure storage container name |
+| config.burrito.datastore.storage.azure.storageAccount | string | `""` | Azure storage account name |
+| config.burrito.datastore.storage.gcs.bucket | string | `""` | GCS bucket name |
+| config.burrito.datastore.storage.mock | bool | `false` | Use in-memory storage for testing - not intended for production use, data will be lost on datastore restart  |
+| config.burrito.datastore.storage.s3.bucket | string | `""` | S3 bucket name |
+| config.burrito.hermitcrab | object | `{}` | Provider cache custom configuration |
+| config.burrito.runner.sshKnownHostsConfigMapName | string | `"burrito-ssh-known-hosts"` | Configmap name to store the SSH known hosts in the runner |
+| config.burrito.server.addr | string | `":8080"` | Server exposed port |
+| config.burrito.server.webhook.github.secret | string | `""` | Secret to validate webhook payload, prefer override with the BURRITO_SERVER_WEBHOOK_GITHUB_SECRET environment variable |
+| config.burrito.server.webhook.gitlab.secret | string | `""` | Secret to validate webhook payload, Prefer override with the BURRITO_SERVER_WEBHOOK_GITLAB_SECRET environment variable |
+| config.create | bool | `true` | Create ConfigMap with Burrito configuration |
+| controllers.deployment | object | `{"args":["controllers","start"],"command":["burrito"],"env":[],"envFrom":[],"livenessProbe":{"httpGet":{"path":"/healthz","port":8081},"initialDelaySeconds":5,"periodSeconds":20},"podAnnotations":{"kubectl.kubernetes.io/default-container":"burrito"},"readinessProbe":{"httpGet":{"path":"/readyz","port":8081},"initialDelaySeconds":5,"periodSeconds":20}}` | Deployment configuration for the Burrito controller |
+| controllers.deployment.args | list | `["controllers","start"]` | Arguments to pass to the Burrito controller container |
+| controllers.deployment.command | list | `["burrito"]` | Command to run in the Burrito controller container |
+| controllers.deployment.env | list | `[]` | Environment variables to pass to the Burrito controller container |
+| controllers.deployment.envFrom | list | `[]` | Environment variables to pass to the Burrito controller container |
+| controllers.deployment.livenessProbe | object | `{"httpGet":{"path":"/healthz","port":8081},"initialDelaySeconds":5,"periodSeconds":20}` | Controller liveness probe configuration |
+| controllers.deployment.podAnnotations | object | `{"kubectl.kubernetes.io/default-container":"burrito"}` | Annotations to be added to the pods generated by the Burrito controller deployment |
+| controllers.deployment.readinessProbe | object | `{"httpGet":{"path":"/readyz","port":8081},"initialDelaySeconds":5,"periodSeconds":20}` | Controller readiness probe configuration |
+| controllers.metadata | object | `{"labels":{"app.kubernetes.io/component":"controllers","app.kubernetes.io/name":"burrito-controllers"}}` | Metadata configuration for the Burrito controller |
+| controllers.service.enabled | bool | `false` | Enable/Disable service creation for the Burrito controller |
+| datastore.deployment.args | list | `["datastore","start"]` | Arguments to pass to the Burrito datastore container |
+| datastore.deployment.command | list | `["burrito"]` | Command to run in the Burrito datastore container |
+| datastore.deployment.envFrom | list | `[]` | Environment variables to pass to the Burrito datastore container |
+| datastore.deployment.livenessProbe | object | `{"httpGet":{"path":"/healthz","port":8080},"initialDelaySeconds":5,"periodSeconds":20}` | Datastore liveness probe configuration |
+| datastore.deployment.podAnnotations | object | `{"kubectl.kubernetes.io/default-container":"burrito"}` | Annotations to be added to the pods generated by the Burrito datastore deployment |
+| datastore.deployment.ports | list | `[{"containerPort":8080,"name":"http"}]` | Datastore exposed port |
+| datastore.deployment.readinessProbe | object | `{"httpGet":{"path":"/healthz","port":8080},"initialDelaySeconds":5,"periodSeconds":20}` | Datastore readiness probe configuration |
+| datastore.metadata | object | `{"labels":{"app.kubernetes.io/component":"datastore","app.kubernetes.io/name":"burrito-datastore"}}` | Metadata configuration for the Burrito datastore |
+| datastore.service | object | `{"ports":[{"name":"http","port":80,"targetPort":"http"},{"name":"https","port":443,"targetPort":"http"}]}` | Service configuration for the Burrito datastore |
+| datastore.tls | object | `{"certManager":{"certificate":{"spec":{"commonName":"burrito-datastore.burrito-system.svc.cluster.local","dnsNames":["burrito-datastore.burrito-system.svc.cluster.local","burrito-datastore.burrito-system","burrito-datastore"],"issuerRef":{"kind":"Issuer","name":"burrito-ca-issuer"},"secretName":"burrito-datastore-tls"}},"use":false}}` | TLS configuration for the Burrito datastore |
+| datastore.tls.certManager.certificate | object | `{"spec":{"commonName":"burrito-datastore.burrito-system.svc.cluster.local","dnsNames":["burrito-datastore.burrito-system.svc.cluster.local","burrito-datastore.burrito-system","burrito-datastore"],"issuerRef":{"kind":"Issuer","name":"burrito-ca-issuer"},"secretName":"burrito-datastore-tls"}}` | CertManager certificate configuration |
+| datastore.tls.certManager.certificate.spec.issuerRef.name | string | `"burrito-ca-issuer"` | The default issuer name is "burrito-ca-issuer", packaged with the chart |
+| datastore.tls.certManager.use | bool | `false` | Use CertManager for Burrito datastore TLS (requires cert-manager to be installed on the cluster) |
+| global.deployment.autoscaling.enabled | bool | `false` | Enable/Disable autoscaling for Burrito pods |
+| global.deployment.envFrom | list | `[]` | Global environment variables  |
+| global.deployment.image | object | `{"pullPolicy":"Always","repository":"ghcr.io/padok-team/burrito","tag":""}` | Global image configuration |
+| global.deployment.podAnnotations | object | `{}` | Global annotations for pods generated by Burrito deployments |
+| global.deployment.podSecurityContext | object | `{"runAsNonRoot":true}` | Global pod security context configuration |
+| global.deployment.ports | list | `[]` | Global ports configuration |
+| global.deployment.replicas | int | `1` | Number of replicas for Burrito pods |
+| global.deployment.resources | object | `{}` | Global resources configuration |
+| global.deployment.securityContext | object | `{"allowPrivilegeEscalation":false,"capabilities":{"drop":["ALL"]}}` | Global security context configuration |
+| global.metadata | object | `{"annotations":{},"labels":{"app.kubernetes.io/part-of":"burrito"}}` | Global metadata configuration  |
+| global.service | object | `{"enabled":true}` | Global service configuration |
+| global.service.enabled | bool | `true` | Enable/Disable service creation for Burrito components |
+| global.serviceAccount.metadata | object | `{"annotations":{},"labels":{}}` | Global metadata configuration for service accounts used by Burrito components |
+| hermitcrab.deployment.affinity | object | `{}` | Hermitcrab affinity |
+| hermitcrab.deployment.env | list | `[{"name":"SERVER_TLS_CERT_FILE","value":"/etc/hermitcrab/tls/tls.crt"},{"name":"SERVER_TLS_PRIVATE_KEY_FILE","value":"/etc/hermitcrab/tls/tls.key"}]` | Hermitcrab environment variables |
+| hermitcrab.deployment.env[0].value | string | `"/etc/hermitcrab/tls/tls.crt"` | Path to the Hermitcrab TLS certificate |
+| hermitcrab.deployment.env[1].value | string | `"/etc/hermitcrab/tls/tls.key"` | Path to the Hermitcrab TLS private key |
+| hermitcrab.deployment.image | object | `{"pullPolicy":"Always","repository":"sealio/hermitcrab","tag":"main"}` | Hermitcrab image configuration |
+| hermitcrab.deployment.livenessProbe | object | `{"failureThreshold":10,"httpGet":{"httpHeaders":[{"name":"User-Agent","value":""}],"path":"/livez","port":80},"periodSeconds":10,"timeoutSeconds":5}` | Hermitcrab liveness probe configuration |
+| hermitcrab.deployment.nodeSelector | object | `{}` | Hermitcrab node selector |
+| hermitcrab.deployment.ports | list | `[{"containerPort":80,"name":"http"},{"containerPort":443,"name":"https"}]` | Hermitcrab ports configuration |
+| hermitcrab.deployment.readinessProbe | object | `{"failureThreshold":3,"httpGet":{"path":"/readyz","port":80},"periodSeconds":5,"timeoutSeconds":5}` | Hermitcrab readiness probe configuration |
+| hermitcrab.deployment.replicas | int | `1` | Hermitcrab replicas |
+| hermitcrab.deployment.resources | object | `{"limits":{"cpu":"1","memory":"2Gi"},"requests":{"cpu":"300m","memory":"256Mi"}}` | Hermitcrab resources configuration |
+| hermitcrab.deployment.startupProbe | object | `{"failureThreshold":10,"httpGet":{"path":"/readyz","port":80},"periodSeconds":5}` | Hermitcrab startup probe configuration |
+| hermitcrab.deployment.tolerations | object | `{}` | Hermitcrab tolerations |
+| hermitcrab.enabled | bool | `false` | Enable/Disable Hermitcrab (terraform provider cache in cluster) |
+| hermitcrab.metadata.labels | object | `{"app.kubernetes.io/component":"hermitcrab","app.kubernetes.io/name":"burrito-hermitcrab"}` | Labels to be added to the Hermitcrab resources |
+| hermitcrab.storage.emptyDir.enabled | bool | `true` | Use emptyDir for Hermitcrab storage |
+| hermitcrab.storage.emptyDir.medium | string | `""` | EmptyDir medium |
+| hermitcrab.storage.emptyDir.sizeLimit | string | `"2Gi"` | EmptyDir size limit |
+| hermitcrab.storage.ephemeral.enabled | bool | `false` | Use ephemeral storage for Hermitcrab storage |
+| hermitcrab.storage.ephemeral.size | string | `"2Gi"` | Ephemeral storage size |
+| hermitcrab.storage.ephemeral.storageClassName | string | `""` | Ephemeral storage class name |
+| hermitcrab.tls.certManager.certificate.spec.commonName | string | `"burrito-hermitcrab.burrito-system.svc.cluster.local"` | Common name for the Hermitcrab TLS certificate |
+| hermitcrab.tls.certManager.certificate.spec.dnsNames | list | `["burrito-hermitcrab.burrito-system.svc.cluster.local","burrito-hermitcrab.burrito-system","burrito-hermitcrab"]` | DNS names for the Hermitcrab TLS certificate |
+| hermitcrab.tls.certManager.certificate.spec.issuerRef.kind | string | `"Issuer"` |  |
+| hermitcrab.tls.certManager.certificate.spec.issuerRef.name | string | `"burrito-ca-issuer"` | The default issuer name is "burrito-ca-issuer", packaged with the chart |
+| hermitcrab.tls.certManager.certificate.spec.secretName | string | `"burrito-hermitcrab-tls"` | Secret name to store the Hermitcrab TLS certificate |
+| hermitcrab.tls.certManager.use | bool | `true` | Use CertManager for Hermitcrab TLS (requires cert-manager to be installed on the cluster) |
+| server.deployment | object | `{"args":["server","start"],"command":["burrito"],"envFrom":[{"secretRef":{"name":"burrito-webhook-secret","optional":true}}],"livenessProbe":{"httpGet":{"path":"/healthz","port":8080},"initialDelaySeconds":5,"periodSeconds":20},"podAnnotations":{"kubectl.kubernetes.io/default-container":"burrito"},"ports":[{"containerPort":8080,"name":"http"}],"readinessProbe":{"httpGet":{"path":"/healthz","port":8080},"initialDelaySeconds":5,"periodSeconds":20}}` | Deployment configuration for the Burrito server |
+| server.deployment.args | list | `["server","start"]` | Arguments to pass to the Burrito server container |
+| server.deployment.command | list | `["burrito"]` | Command to run in the Burrito server container |
+| server.deployment.envFrom | list | `[{"secretRef":{"name":"burrito-webhook-secret","optional":true}}]` | Environment variables to pass to the Burrito server container |
+| server.deployment.envFrom[0] | object | `{"secretRef":{"name":"burrito-webhook-secret","optional":true}}` | Reference the webhook secret here, it should define a BURRITO_SERVER_WEBHOOK_GITHUB_SECRET and/or BURRITO_SERVER_WEBHOOK_GITLAB_SECRET key |
+| server.deployment.livenessProbe | object | `{"httpGet":{"path":"/healthz","port":8080},"initialDelaySeconds":5,"periodSeconds":20}` | Server liveness probe configuration |
+| server.deployment.podAnnotations | object | `{"kubectl.kubernetes.io/default-container":"burrito"}` | Annotations to be added to the pods generated by the Burrito server deployment |
+| server.deployment.ports | list | `[{"containerPort":8080,"name":"http"}]` | Server exposed port |
+| server.deployment.readinessProbe | object | `{"httpGet":{"path":"/healthz","port":8080},"initialDelaySeconds":5,"periodSeconds":20}` | Server readiness probe configuration |
+| server.ingress | object | `{"annotations":{},"enabled":false,"host":"burrito.example.com","ingressClassName":"nginx","tls":[]}` | Ingress configuration for the Burrito server |
+| server.ingress.annotations | object | `{}` | Annotations to be added to the Burrito server ingress |
+| server.ingress.enabled | bool | `false` | Enable/Disable ingress creation for the Burrito server |
+| server.ingress.host | string | `"burrito.example.com"` | Hostname for the Burrito server ingress |
+| server.ingress.ingressClassName | string | `"nginx"` | Ingress class name to use for the Burrito server ingress |
+| server.ingress.tls | list | `[]` | TLS configuration for the Burrito server ingress |
+| server.metadata | object | `{"labels":{"app.kubernetes.io/component":"server","app.kubernetes.io/name":"burrito-server"}}` | Metadata configuration for the Burrito server |
+| server.service | object | `{"ports":[{"name":"http","port":80,"targetPort":"http"}]}` | Service configuration for the Burrito server |
+| tenants | string | `nil` | List of tenants to create to manage Terraform resources |
+
+----------------------------------------------
+Autogenerated from chart metadata using [helm-docs v1.14.2](https://github.com/norwoodj/helm-docs/releases/v1.14.2)

--- a/deploy/charts/burrito/templates/config.yaml
+++ b/deploy/charts/burrito/templates/config.yaml
@@ -26,9 +26,13 @@ Datastore Authorized Service Accounts
 {{- $server := printf "%s/%s" .Release.Namespace "burrito-server" }}
 {{- $datastoreAuthorizedServiceAccounts = append $datastoreAuthorizedServiceAccounts $server }}
 {{- $_ := set $config.datastore "serviceAccounts" $datastoreAuthorizedServiceAccounts }}
+{{- if .Values.hermitcrab.tls.certManager.use }}
 {{- $_ := set $config.hermitcrab "certificateSecretName" .Values.hermitcrab.tls.certManager.certificate.spec.secretName }}
+{{- else }}
+{{- $_ := set $config.hermitcrab "certificateSecretName" .Values.hermitcrab.tls.secretName }}
+{{- end }}
 {{- $_ := set $config.hermitcrab "enabled" .Values.hermitcrab.enabled }}
-{{- $_ := set $config.datastore "tls" .Values.datastore.tls.certManager.use }}
+{{- $_ := set $config.datastore "tls" .Values.datastore.tls.enabled }}
 
 
 apiVersion: v1

--- a/deploy/charts/burrito/templates/controllers.yaml
+++ b/deploy/charts/burrito/templates/controllers.yaml
@@ -63,7 +63,7 @@ spec:
             - name: burrito-token
               mountPath: /var/run/secrets/token
               readOnly: true
-            {{- if $.Values.datastore.tls.certManager.use }}
+            {{- if $.Values.datastore.tls.enabled }}
             - name: burrito-ca
               mountPath: /etc/ssl/certs/burrito-ca.crt
               subPath: burrito-ca.crt
@@ -92,12 +92,19 @@ spec:
                 audience: burrito
                 expirationSeconds: 3600
                 path: burrito
-        {{- if $.Values.datastore.tls.certManager.use }}
+        {{- if and $.Values.datastore.tls.enabled $.Values.datastore.tls.certManager.use }}
         - name: burrito-ca
           secret:
             secretName: {{ $.Values.datastore.tls.certManager.certificate.spec.secretName }}
             items:
               - key: ca.crt
+                path: burrito-ca.crt
+        {{- else if $.Values.datastore.tls.enabled }}
+        - name: burrito-ca
+          secret:
+            secretName: {{ $.Values.datastore.tls.secretName }}
+            items:
+              - key: {{ $.Values.datastore.tls.caKey }}
                 path: burrito-ca.crt
         {{- end }}
 {{- if .service.enabled }}

--- a/deploy/charts/burrito/templates/datastore.yaml
+++ b/deploy/charts/burrito/templates/datastore.yaml
@@ -1,7 +1,7 @@
 {{ $configChecksum := (include (print $.Template.BasePath "/config.yaml") . | sha256sum) }}
 
 {{- with mergeOverwrite (deepCopy .Values.global) .Values.datastore }}
-{{- if .tls.certManager.use }}
+{{- if .tls.enabled }}
 {{- $_ := set .deployment.livenessProbe.httpGet "scheme" "HTTPS" }}
 {{- $_ := set .deployment.readinessProbe.httpGet "scheme" "HTTPS" }}
 {{- else }}
@@ -64,7 +64,7 @@ spec:
             - name: burrito-config
               mountPath: /etc/burrito
               readOnly: true
-            {{- if .tls.certManager.use }}
+            {{- if .tls.enabled }}
             - name: burrito-datastore-tls
               mountPath: /etc/burrito/tls
               readOnly: true
@@ -85,10 +85,14 @@ spec:
         - name: burrito-config
           configMap:
             name: burrito-config
-        {{- if .tls.certManager.use }}
+        {{- if and .tls.enabled .tls.certManager.use }}
         - name: burrito-datastore-tls
           secret:
             secretName: {{ .tls.certManager.certificate.spec.secretName }}
+        {{- else if .tls.enabled }}
+        - name: burrito-datastore-tls
+          secret:
+            secretName: {{ .tls.secretName }}
         {{- end }}
 {{- if .service.enabled }}
 ---
@@ -136,7 +140,7 @@ subjects:
     name: burrito-datastore
     namespace: {{ $.Release.Namespace }}
 ---
-{{- if .tls.certManager.use }}
+{{- if and .tls.enabled .tls.certManager.use }}
 apiVersion: cert-manager.io/v1
 kind: Certificate
 metadata:

--- a/deploy/charts/burrito/templates/hermitcrab.yaml
+++ b/deploy/charts/burrito/templates/hermitcrab.yaml
@@ -48,21 +48,16 @@ spec:
             {{- toYaml .deployment.livenessProbe | nindent 12 }}
           readinessProbe:
             {{- toYaml .deployment.readinessProbe | nindent 12 }}
-          {{- if or .storage.emptyDir.enabled .storage.ephemeral.enabled .tls.certManager.use .deployment.extraVolumeMounts }}
           volumeMounts:
             {{- if or .storage.emptyDir.enabled .storage.ephemeral.enabled }}
             - name: provider-cache
               mountPath: /var/run/hermitcrab
             {{- end }}
-            {{- if .tls.certManager.use }}
             - name: burrito-hermitcrab-tls
               mountPath: /etc/hermitcrab/tls
-            {{- end }}
             {{- if .deployment.extraVolumeMounts }}
             {{- toYaml .deployment.extraVolumeMounts | nindent 12 }}
             {{- end }}
-          {{- end }}
-      {{- if or .storage.emptyDir.enabled .storage.ephemeral.enabled .tls.certManager.use .deployment.extraVolumes }}
       volumes:
         {{- if or .storage.emptyDir.enabled .storage.ephemeral.enabled }}
         - name: provider-cache
@@ -85,11 +80,14 @@ spec:
         - name: burrito-hermitcrab-tls
           secret:
             secretName: {{ .tls.certManager.certificate.spec.secretName }}
+        {{- else }}
+        - name: burrito-hermitcrab-tls
+          secret:
+            secretName: {{ .tls.secretName }}
         {{- end }}
         {{- if .deployment.extraVolumes }}
         {{- toYaml .deployment.extraVolumes | nindent 8 }}
         {{- end }}
-      {{- end }}
       tolerations:
         {{- toYaml .deployment.tolerations | nindent 8 }}
       nodeSelector:

--- a/deploy/charts/burrito/templates/issuer.yaml
+++ b/deploy/charts/burrito/templates/issuer.yaml
@@ -1,3 +1,4 @@
+{{- if or (and .Values.hermitcrab.enabled .Values.hermitcrab.tls.certManager.use) (and .Values.datastore.tls.enabled .Values.datastore.tls.certManager.use) }}
 apiVersion: cert-manager.io/v1
 kind: Issuer
 metadata:
@@ -28,3 +29,4 @@ metadata:
 spec:
   ca:
     secretName: burrito-ca
+{{- end }}

--- a/deploy/charts/burrito/templates/server.yaml
+++ b/deploy/charts/burrito/templates/server.yaml
@@ -62,7 +62,7 @@ spec:
             - name: burrito-token
               mountPath: /var/run/secrets/token
               readOnly: true
-            {{- if $.Values.datastore.tls.certManager.use }}
+            {{- if $.Values.datastore.tls.enabled }}
             - name: burrito-ca
               mountPath: /etc/ssl/certs/burrito-ca.crt
               subPath: burrito-ca.crt
@@ -91,10 +91,17 @@ spec:
                 audience: burrito
                 expirationSeconds: 3600
                 path: burrito
-        {{- if $.Values.datastore.tls.certManager.use }}
+        {{- if and $.Values.datastore.tls.enabled $.Values.datastore.tls.certManager.use }}
         - name: burrito-ca
           secret:
             secretName: {{ $.Values.datastore.tls.certManager.certificate.spec.secretName }}
+            items:
+              - key: ca.crt
+                path: burrito-ca.crt
+        {{- else if $.Values.datastore.tls.enabled }}
+        - name: burrito-ca
+          secret:
+            secretName: {{ $.Values.datastore.tls.secretName }}
             items:
               - key: ca.crt
                 path: burrito-ca.crt

--- a/deploy/charts/burrito/values.yaml
+++ b/deploy/charts/burrito/values.yaml
@@ -17,16 +17,35 @@ config:
     controller:
       # -- By default, the controller will only watch the tenants namespaces
       namespaces: []
-      timers: {}
+      # -- Timer configuration
+      timers:
+        # -- Drift detection interval
+        driftDetection: 10m
+        # -- Duration to wait before retrying on error
+        onError: 10s
+        # -- Duration to wait before retrying on locked layer
+        waitAction: 1m
+        # -- Duration to wait before retrying on failure (increases exponentially with the amount of failed retries)
+        failureGracePeriod: 30
+      # -- Maximum number of concurrent reconciles for the controller, increse this value if you have a lot of resources to reconcile
       maxConcurrentReconciles: 1
+      # -- Maximum number of retries for Terraform operations (plan, apply...)
       terraformMaxRetries: 3
+      # -- Resource types to watch for reconciliation
       types: ["layer", "repository", "run", "pullrequest"]
+      # -- Leader election configuration
       leaderElection:
+        # -- Enable/Disable leader election
         enabled: true
+        # -- Leader election lock name
         id: 6d185457.terraform.padok.cloud
+      # -- Adress to bind the controller metrics
       metricsBindAddress: ":8080"
+      # -- Adress to bind the controller health probe
       healthProbeBindAddress: ":8081"
+      # -- Port used to handle the Kubernetes webhook
       kubernetesWebhookPort: 9443
+      # -- GitHub configuration
       githubConfig:
         # -- Prefer override with the BURRITO_CONTROLLER_GITHUBCONFIG_APPID environment variable
         appId: ""
@@ -36,83 +55,132 @@ config:
         privateKey: ""
         # -- Prefer override with the BURRITO_CONTROLLER_GITHUBCONFIG_APITOKEN environment variable
         apiToken: ""
+      # -- GitLab configuration
       gitlabConfig:
         # -- Prefer override with the BURRITO_CONTROLLER_GITLABCONFIG_APITOKEN environment variable
         apiToken: ""
         url: ""
+    # -- Provider cache custom configuration
     hermitcrab: {}
+    # -- Datastore configuration
     datastore:
+      # -- Service account to use for datastore operations (e.g. reading/writing to storage)
       serviceAccounts: []
       storage:
-        mock: false # -- Use in-memory storage for testing - not intended for production use 
+        # -- Use in-memory storage for testing - not intended for production use, data will be lost on datastore restart 
+        mock: false 
+        # -- GCS configuration
         gcs:
+          # -- GCS bucket name
           bucket: ""
+        # -- Azure storage configuration
         azure:
+          # -- Azure storage account name
           storageAccount: ""
+          # -- Azure storage container name
           container: ""
+        # -- S3 configuration
         s3: 
+          # -- S3 bucket name
           bucket: ""
+      # -- Datastore exposed port
       addr: ":8080"
 
-    # Burrito server configuration
+    # -- Burrito server configuration
     server:
+      # -- Server exposed port
       addr: ":8080"
+      # -- Github/Gitlab webhook handling configuration
       webhook:
+        # -- Github webhook configuration
         github:
-          # -- Prefer override with the BURRITO_SERVER_WEBHOOK_GITHUB_SECRET environment variable
+          # -- Secret to validate webhook payload, prefer override with the BURRITO_SERVER_WEBHOOK_GITHUB_SECRET environment variable
           secret: ""
+        # -- Gitlab webhook configuration
         gitlab:
-          # -- Prefer override with the BURRITO_SERVER_WEBHOOK_GITLAB_SECRET environment variable
+          # -- Secret to validate webhook payload, Prefer override with the BURRITO_SERVER_WEBHOOK_GITLAB_SECRET environment variable
           secret: ""
 
-    # Burrito runners configuration
+    # -- Burrito runnners configuration
     runner:
+      # -- Configmap name to store the SSH known hosts
       sshKnownHostsConfigMapName: burrito-ssh-known-hosts
 
+# -- Terraform provider cache configuration (Hermitcrab)
 hermitcrab:
+  # -- Enable/Disable Hermitcrab
   enabled: false
+  # -- Metadata for Hermitcrab resources
   metadata:
+    # -- Labels to be added to the Hermitcrab resources
     labels:
       app.kubernetes.io/component: hermitcrab
       app.kubernetes.io/name: burrito-hermitcrab
+  # -- Hermitcrab storage configuration
   storage:
+    # -- EmptyDir configuration
     emptyDir:
+      # -- Use emptyDir for Hermitcrab storage
       enabled: true
+      # -- EmptyDir medium
       medium: ""
+      # -- EmptyDir size limit
       sizeLimit: "2Gi"
+    # -- Ephemeral storage configuration
     ephemeral:
+      # -- Use ephemeral storage for Hermitcrab storage
       enabled: false
+      # -- Ephemeral storage size
       size: "2Gi"
+      # -- Ephemeral storage class name
       storageClassName: ""
+  # -- Hermitcrab TLS configuration
   tls:
+    # -- CertManager configuration
     certManager:
+      # -- Use CertManager for Hermitcrab TLS (requires cert-manager to be installed on the cluster)
       use: true
+      # -- CertManager certificate configuration
       certificate:
         spec:
+          # -- Secret name to store the Hermitcrab TLS certificate
           secretName: burrito-hermitcrab-tls
+          # -- Common name for the Hermitcrab TLS certificate
           commonName: burrito-hermitcrab.burrito-system.svc.cluster.local
+          # -- DNS names for the Hermitcrab TLS certificate
           dnsNames:
             - burrito-hermitcrab.burrito-system.svc.cluster.local
             - burrito-hermitcrab.burrito-system
             - burrito-hermitcrab
+          # -- Issuer reference for the Hermitcrab TLS certificate
           issuerRef:
+            # -- The default issuer name is "burrito-ca-issuer", packaged with the chart
             name: burrito-ca-issuer
             kind: Issuer
-
+  # -- Hermitcrab deployment configuration
   deployment:
+    # -- Hermitcrab replicas
     replicas: 1
+    # -- Hermitcrab tolerations
     tolerations: {}
+    # -- Hermitcrab node selector
     nodeSelector: {}
+    # -- Hermitcrab affinity
     affinity: {}
+    # -- Hermitcrab image configuration
     image:
       pullPolicy: Always
       repository: sealio/hermitcrab
       tag: main
+    # -- Hermitcrab environment variables
     env:
       - name: SERVER_TLS_CERT_FILE
+        # -- Path to the Hermitcrab TLS certificate
         value: /etc/hermitcrab/tls/tls.crt
       - name: SERVER_TLS_PRIVATE_KEY_FILE
+        # -- Path to the Hermitcrab TLS private key
         value: /etc/hermitcrab/tls/tls.key
+    # -- Hermitcrab resources configuration
     resources:
       limits:
         cpu: '1'
@@ -120,17 +188,20 @@ hermitcrab:
       requests:
         cpu: '300m'
         memory: '256Mi'
+    # -- Hermitcrab ports configuration
     ports:
       - name: http
         containerPort: 80
       - name: https
         containerPort: 443
+    # -- Hermitcrab startup probe configuration
     startupProbe:
       failureThreshold: 10
       periodSeconds: 5
       httpGet:
         port: 80
         path: /readyz
+    # -- Hermitcrab readiness probe configuration
     readinessProbe:
       failureThreshold: 3
       timeoutSeconds: 5
@@ -138,6 +209,7 @@ hermitcrab:
       httpGet:
         port: 80
         path: /readyz
+    # -- Hermitcrab liveness probe configuration
     livenessProbe:
       failureThreshold: 10
       timeoutSeconds: 5
@@ -149,133 +221,185 @@ hermitcrab:
         port: 80
         path: /livez
 
+# -- Burrito global configuration (applied to all components)
 global:
+  # -- Global metadata configuration 
   metadata:
     labels:
       app.kubernetes.io/part-of: burrito
     annotations: {}
+  # -- Global deployment configuration
   deployment:
     autoscaling:
+      # -- Enable/Disable autoscaling for Burrito pods
       enabled: false
+    # --  Number of replicas for Burrito pods
     replicas: 1
+    # -- Global image configuration
     image:
       repository: ghcr.io/padok-team/burrito
       tag: "" # By default use Chart's appVersion
       pullPolicy: Always
+    # -- Global annotations for pods generated by Burrito deployments
     podAnnotations: {}
+    # -- Global pod security context configuration
     podSecurityContext:
       runAsNonRoot: true
+    # -- Global security context configuration
     securityContext:
       allowPrivilegeEscalation: false
       capabilities:
         drop:
           - "ALL"
+    # -- Global resources configuration
     resources: {}
+    # -- Global ports configuration
     ports: []
+    # -- Global environment variables 
     envFrom: []
+  # -- Global service configuration
   service:
+    # -- Enable/Disable service creation for Burrito components
     enabled: true
   serviceAccount:
+    # -- Global metadata configuration for service accounts used by Burrito components
     metadata:
       annotations: {}
       labels: {}
 
+# -- Burrito controller configuration
 controllers:
+  # -- Metadata configuration for the Burrito controller
   metadata:
     labels:
       app.kubernetes.io/component: controllers
       app.kubernetes.io/name: burrito-controllers
+  # -- Deployment configuration for the Burrito controller
   deployment:
+    # -- Annotations to be added to the pods generated by the Burrito controller deployment
     podAnnotations:
       kubectl.kubernetes.io/default-container: burrito
+    # -- Command to run in the Burrito controller container
     command: ["burrito"]
+    # -- Arguments to pass to the Burrito controller container
     args: ["controllers", "start"]
+    # -- Controller liveness probe configuration
     livenessProbe:
       httpGet:
         path: /healthz
         port: 8081
       initialDelaySeconds: 5
       periodSeconds: 20
+    # -- Controller readiness probe configuration
     readinessProbe:
       httpGet:
         path: /readyz
         port: 8081
       initialDelaySeconds: 5
       periodSeconds: 20
+    # -- Environment variables to pass to the Burrito controller container
     envFrom: []
+    # -- Environment variables to pass to the Burrito controller container
     env: []
   service:
+    # -- Enable/Disable service creation for the Burrito controller
     enabled: false
 
 server:
+  # -- Metadata configuration for the Burrito server
   metadata:
     labels:
       app.kubernetes.io/component: server
       app.kubernetes.io/name: burrito-server
+  # -- Deployment configuration for the Burrito server
   deployment:
+    # -- Annotations to be added to the pods generated by the Burrito server deployment
     podAnnotations:
       kubectl.kubernetes.io/default-container: burrito
+    # -- Command to run in the Burrito server container
     command: ["burrito"]
+    # -- Arguments to pass to the Burrito server container
     args: ["server", "start"]
+    # -- Server exposed port
     ports:
       - name: http
         containerPort: 8080
+    # -- Server liveness probe configuration
     livenessProbe:
       httpGet:
         path: /healthz
         port: 8080
       initialDelaySeconds: 5
       periodSeconds: 20
+    # -- Server readiness probe configuration
     readinessProbe:
       httpGet:
         path: /healthz
         port: 8080
       initialDelaySeconds: 5
       periodSeconds: 20
+    # -- Environment variables to pass to the Burrito server container
     envFrom:
-      # -- Reference the webhook secret here
-      ## It should define a BURRITO_SERVER_WEBHOOK_GITHUB_SECRET and/or BURRITO_SERVER_WEBHOOK_GITLAB_SECRET key
+      # -- Reference the webhook secret here, it should define a BURRITO_SERVER_WEBHOOK_GITHUB_SECRET and/or BURRITO_SERVER_WEBHOOK_GITLAB_SECRET key
       - secretRef:
           name: burrito-webhook-secret
           optional: true
+  # -- Service configuration for the Burrito server
   service:
     ports:
       - name: http
         port: 80
         targetPort: http
+  # -- Ingress configuration for the Burrito server
   ingress:
+    # -- Enable/Disable ingress creation for the Burrito server
     enabled: false
+    # -- Annotations to be added to the Burrito server ingress
     annotations: {}
+    # -- Ingress class name to use for the Burrito server ingress
     ingressClassName: nginx
+    # -- Hostname for the Burrito server ingress
     host: burrito.example.com
+    # -- TLS configuration for the Burrito server ingress
     tls: []
 
+# -- Burrito datastore configuration
 datastore:
+  # -- Metadata configuration for the Burrito datastore
   metadata:
     labels:
       app.kubernetes.io/component: datastore
       app.kubernetes.io/name: burrito-datastore
+  # -- Deployment configuration for the Burrito datastore
   deployment:
+    # -- Annotations to be added to the pods generated by the Burrito datastore deployment
     podAnnotations:
       kubectl.kubernetes.io/default-container: burrito
+    # -- Command to run in the Burrito datastore container
     command: ["burrito"]
+    # -- Arguments to pass to the Burrito datastore container
     args: ["datastore", "start"]
+    # -- Datastore exposed port
     ports:
       - name: http
         containerPort: 8080
+    # -- Datastore liveness probe configuration
     livenessProbe:
       httpGet:
         path: /healthz
         port: 8080
       initialDelaySeconds: 5
       periodSeconds: 20
+    # -- Datastore readiness probe configuration
     readinessProbe:
       httpGet:
         path: /healthz
         port: 8080
       initialDelaySeconds: 5
       periodSeconds: 20
+    # -- Environment variables to pass to the Burrito datastore container
     envFrom: []
+  # -- Service configuration for the Burrito datastore
   service:
     ports:
     - name: http
@@ -284,9 +408,12 @@ datastore:
     - name: https
       port: 443
       targetPort: http
+  # -- TLS configuration for the Burrito datastore
   tls:
     certManager:
+      # -- Use CertManager for Burrito datastore TLS (requires cert-manager to be installed on the cluster)
       use: false
+      # -- CertManager certificate configuration
       certificate:
         spec:
           secretName: burrito-datastore-tls
@@ -296,7 +423,24 @@ datastore:
             - burrito-datastore.burrito-system
             - burrito-datastore
           issuerRef:
+            # -- The default issuer name is "burrito-ca-issuer", packaged with the chart
             name: burrito-ca-issuer
             kind: Issuer
 
-tenants: []
+# -- List of tenants to create to manage Terraform resources
+tenants:
+# - namespace:
+#     create: true
+#     name: "burrito-project-1"
+#     labels: {}
+#     annotations: {}
+#   serviceAccounts:
+#     - name: runner-project-1
+#       additionalRoleBindings:
+#         - name: custom
+#           role:
+#             kind: ClusterRole
+#             name: my-custom-role
+#       annotations:
+#         iam.cloud.provider/role: cloud-provider-role
+#       labels: {}

--- a/deploy/charts/burrito/values.yaml
+++ b/deploy/charts/burrito/values.yaml
@@ -11,13 +11,10 @@ config:
   # -- Annotations to be added to the ConfigMap
   annotations: {}
 
-  # -- Burrito configuration in YAML format
   burrito:
-    # Burrito controller configuration
     controller:
       # -- By default, the controller will only watch the tenants namespaces
       namespaces: []
-      # -- Timer configuration
       timers:
         # -- Drift detection interval
         driftDetection: 10m
@@ -33,7 +30,6 @@ config:
       terraformMaxRetries: 3
       # -- Resource types to watch for reconciliation
       types: ["layer", "repository", "run", "pullrequest"]
-      # -- Leader election configuration
       leaderElection:
         # -- Enable/Disable leader election
         enabled: true
@@ -45,80 +41,66 @@ config:
       healthProbeBindAddress: ":8081"
       # -- Port used to handle the Kubernetes webhook
       kubernetesWebhookPort: 9443
-      # -- GitHub configuration
       githubConfig:
-        # -- Prefer override with the BURRITO_CONTROLLER_GITHUBCONFIG_APPID environment variable
+        # -- Github app ID, prefer override with the BURRITO_CONTROLLER_GITHUBCONFIG_APPID environment variable
         appId: ""
-        # -- Prefer override with the BURRITO_CONTROLLER_GITHUBCONFIG_INSTALLATIONID environment variable
+        # -- Github app unstallation ID, prefer override with the BURRITO_CONTROLLER_GITHUBCONFIG_INSTALLATIONID environment variable
         installationId: ""
-        # -- Prefer override with the BURRITO_CONTROLLER_GITHUBCONFIG_PRIVATEKEY environment variable
+        # -- Github app private key, prefer override with the BURRITO_CONTROLLER_GITHUBCONFIG_PRIVATEKEY environment variable
         privateKey: ""
-        # -- Prefer override with the BURRITO_CONTROLLER_GITHUBCONFIG_APITOKEN environment variable
+        # -- Github API token, prefer override with the BURRITO_CONTROLLER_GITHUBCONFIG_APITOKEN environment variable
         apiToken: ""
-      # -- GitLab configuration
       gitlabConfig:
-        # -- Prefer override with the BURRITO_CONTROLLER_GITLABCONFIG_APITOKEN environment variable
+        # -- Gitlab API token Prefer override with the BURRITO_CONTROLLER_GITLABCONFIG_APITOKEN environment variable
         apiToken: ""
+        # -- Gitlab URL
         url: ""
     # -- Provider cache custom configuration
     hermitcrab: {}
-    # -- Datastore configuration
     datastore:
       # -- Service account to use for datastore operations (e.g. reading/writing to storage)
       serviceAccounts: []
       storage:
         # -- Use in-memory storage for testing - not intended for production use, data will be lost on datastore restart 
         mock: false 
-        # -- GCS configuration
         gcs:
           # -- GCS bucket name
           bucket: ""
-        # -- Azure storage configuration
         azure:
           # -- Azure storage account name
           storageAccount: ""
           # -- Azure storage container name
           container: ""
-        # -- S3 configuration
         s3: 
           # -- S3 bucket name
           bucket: ""
       # -- Datastore exposed port
       addr: ":8080"
 
-    # -- Burrito server configuration
     server:
       # -- Server exposed port
       addr: ":8080"
-      # -- Github/Gitlab webhook handling configuration
       webhook:
-        # -- Github webhook configuration
         github:
           # -- Secret to validate webhook payload, prefer override with the BURRITO_SERVER_WEBHOOK_GITHUB_SECRET environment variable
           secret: ""
-        # -- Gitlab webhook configuration
         gitlab:
           # -- Secret to validate webhook payload, Prefer override with the BURRITO_SERVER_WEBHOOK_GITLAB_SECRET environment variable
           secret: ""
 
-    # -- Burrito runnners configuration
     runner:
-      # -- Configmap name to store the SSH known hosts
+      # -- Configmap name to store the SSH known hosts in the runner
       sshKnownHostsConfigMapName: burrito-ssh-known-hosts
 
-# -- Terraform provider cache configuration (Hermitcrab)
-hermitcrab:
-  # -- Enable/Disable Hermitcrab
+hermitcrab: 
+  # -- Enable/Disable Hermitcrab (terraform provider cache in cluster)
   enabled: false
-  # -- Metadata for Hermitcrab resources
   metadata:
     # -- Labels to be added to the Hermitcrab resources
     labels:
       app.kubernetes.io/component: hermitcrab
       app.kubernetes.io/name: burrito-hermitcrab
-  # -- Hermitcrab storage configuration
   storage:
-    # -- EmptyDir configuration
     emptyDir:
       # -- Use emptyDir for Hermitcrab storage
       enabled: true
@@ -126,7 +108,6 @@ hermitcrab:
       medium: ""
       # -- EmptyDir size limit
       sizeLimit: "2Gi"
-    # -- Ephemeral storage configuration
     ephemeral:
       # -- Use ephemeral storage for Hermitcrab storage
       enabled: false
@@ -134,13 +115,10 @@ hermitcrab:
       size: "2Gi"
       # -- Ephemeral storage class name
       storageClassName: ""
-  # -- Hermitcrab TLS configuration
   tls:
-    # -- CertManager configuration
     certManager:
       # -- Use CertManager for Hermitcrab TLS (requires cert-manager to be installed on the cluster)
       use: true
-      # -- CertManager certificate configuration
       certificate:
         spec:
           # -- Secret name to store the Hermitcrab TLS certificate
@@ -152,12 +130,10 @@ hermitcrab:
             - burrito-hermitcrab.burrito-system.svc.cluster.local
             - burrito-hermitcrab.burrito-system
             - burrito-hermitcrab
-          # -- Issuer reference for the Hermitcrab TLS certificate
           issuerRef:
             # -- The default issuer name is "burrito-ca-issuer", packaged with the chart
             name: burrito-ca-issuer
             kind: Issuer
-  # -- Hermitcrab deployment configuration
   deployment:
     # -- Hermitcrab replicas
     replicas: 1
@@ -221,14 +197,12 @@ hermitcrab:
         port: 80
         path: /livez
 
-# -- Burrito global configuration (applied to all components)
 global:
   # -- Global metadata configuration 
   metadata:
     labels:
       app.kubernetes.io/part-of: burrito
     annotations: {}
-  # -- Global deployment configuration
   deployment:
     autoscaling:
       # -- Enable/Disable autoscaling for Burrito pods
@@ -267,7 +241,6 @@ global:
       annotations: {}
       labels: {}
 
-# -- Burrito controller configuration
 controllers:
   # -- Metadata configuration for the Burrito controller
   metadata:
@@ -363,14 +336,12 @@ server:
     # -- TLS configuration for the Burrito server ingress
     tls: []
 
-# -- Burrito datastore configuration
 datastore:
   # -- Metadata configuration for the Burrito datastore
   metadata:
     labels:
       app.kubernetes.io/component: datastore
       app.kubernetes.io/name: burrito-datastore
-  # -- Deployment configuration for the Burrito datastore
   deployment:
     # -- Annotations to be added to the pods generated by the Burrito datastore deployment
     podAnnotations:

--- a/deploy/charts/burrito/values.yaml
+++ b/deploy/charts/burrito/values.yaml
@@ -116,8 +116,10 @@ hermitcrab:
       # -- Ephemeral storage class name
       storageClassName: ""
   tls:
+    # -- Reference a secret that contains a CA cer (ca.crt, tls.crt, tls.key) for Hermitcrab (if not using CertManager) - note: TLS is required for Hermitcrab, as Terraform Provider Mirror protocol requires it
+    secretName: burrito-hermitcrab-tls
     certManager:
-      # -- Use CertManager for Hermitcrab TLS (requires cert-manager to be installed on the cluster)
+      # -- Use CertManager for Hermitcrab TLS (recommended - requires cert-manager to be installed on the cluster)
       use: true
       certificate:
         spec:
@@ -138,7 +140,7 @@ hermitcrab:
     # -- Hermitcrab replicas
     replicas: 1
     # -- Hermitcrab tolerations
-    tolerations: {}
+    tolerations: []
     # -- Hermitcrab node selector
     nodeSelector: {}
     # -- Hermitcrab affinity
@@ -381,9 +383,13 @@ datastore:
       targetPort: http
   # -- TLS configuration for the Burrito datastore
   tls:
+    # -- Enable/Disable TLS for the Burrito datastore (recommended for production use)
+    enabled: false
+    # -- Reference a secret that contains a CA certificate (ca.crt, tls.crt, tls.key) for the Burrito datastore (if not using CertManager)
+    secretName: burrito-datastore-tls
     certManager:
-      # -- Use CertManager for Burrito datastore TLS (requires cert-manager to be installed on the cluster)
-      use: false
+      # -- Use CertManager for Burrito datastore TLS (recommended - requires cert-manager to be installed on the cluster)
+      use: true
       # -- CertManager certificate configuration
       certificate:
         spec:


### PR DESCRIPTION
This adds comments to all values in the helm chart to better understand what is configurable. I used https://github.com/norwoodj/helm-docs to automatically generate a README file as helm chart documentation.

Most importantly, this PR also makes cert-manager not required to run Burrito and disables TLS for the datastore in the chart default values. This aims at easing the installation process for Burrito, while making clear that using TLS is strongly recommended and very easy to setup with cert-manager.