### PR TITLE
allow add extra volumes and mounts in Helm chart

### DIFF
--- a/deploy/charts/burrito/templates/controllers.yaml
+++ b/deploy/charts/burrito/templates/controllers.yaml
@@ -69,6 +69,9 @@ spec:
               subPath: burrito-ca.crt
               readOnly: true
             {{- end }}
+            {{- if .deployment.extraVolumeMounts }}
+            {{- toYaml .deployment.extraVolumeMounts | nindent 12 }}
+            {{- end }}
       {{- with .deployment.nodeSelector }}
       nodeSelector:
         {{- toYaml . | nindent 8 }}
@@ -106,6 +109,9 @@ spec:
             items:
               - key: {{ $.Values.datastore.tls.caKey }}
                 path: burrito-ca.crt
+        {{- end }}
+        {{- if .deployment.extraVolumes }}
+        {{- toYaml .deployment.extraVolumes | nindent 8 }}
         {{- end }}
 {{- if .service.enabled }}
 ---

--- a/deploy/charts/burrito/templates/datastore.yaml
+++ b/deploy/charts/burrito/templates/datastore.yaml
@@ -69,6 +69,9 @@ spec:
               mountPath: /etc/burrito/tls
               readOnly: true
             {{- end }}
+            {{- if .deployment.extraVolumeMounts }}
+            {{- toYaml .deployment.extraVolumeMounts | nindent 12 }}
+            {{- end }}
       {{- with .deployment.nodeSelector }}
       nodeSelector:
         {{- toYaml . | nindent 8 }}
@@ -93,6 +96,9 @@ spec:
         - name: burrito-datastore-tls
           secret:
             secretName: {{ .tls.secretName }}
+        {{- end }}
+        {{- if .deployment.extraVolumes }}
+        {{- toYaml .deployment.extraVolumes | nindent 8 }}
         {{- end }}
 {{- if .service.enabled }}
 ---

--- a/deploy/charts/burrito/templates/server.yaml
+++ b/deploy/charts/burrito/templates/server.yaml
@@ -68,6 +68,9 @@ spec:
               subPath: burrito-ca.crt
               readOnly: true
             {{- end }}
+            {{- if .deployment.extraVolumeMounts }}
+            {{- toYaml .deployment.extraVolumeMounts | nindent 12 }}
+            {{- end }}
       {{- with .deployment.nodeSelector }}
       nodeSelector:
         {{- toYaml . | nindent 8 }}
@@ -105,6 +108,9 @@ spec:
             items:
               - key: ca.crt
                 path: burrito-ca.crt
+        {{- end }}
+        {{- if .deployment.extraVolumes }}
+        {{- toYaml .deployment.extraVolumes | nindent 8 }}
         {{- end }}
 {{- if .service.enabled }}
 ---

--- a/deploy/charts/burrito/values.yaml
+++ b/deploy/charts/burrito/values.yaml
@@ -198,6 +198,10 @@ hermitcrab:
             value: ""
         port: 80
         path: /livez
+    # -- Additional volumes
+    extraVolumes: {}
+    # -- Additional volume mounts
+    extraVolumeMounts: {}
 
 global:
   # -- Global metadata configuration 
@@ -233,6 +237,10 @@ global:
     ports: []
     # -- Global environment variables 
     envFrom: []
+    # -- Additional volumes
+    extraVolumes: {}
+    # -- Additional volume mounts
+    extraVolumeMounts: {}
   # -- Global service configuration
   service:
     # -- Enable/Disable service creation for Burrito components
@@ -276,6 +284,10 @@ controllers:
     envFrom: []
     # -- Environment variables to pass to the Burrito controller container
     env: []
+    # -- Additional volumes
+    extraVolumes: {}
+    # -- Additional volume mounts
+    extraVolumeMounts: {}
   service:
     # -- Enable/Disable service creation for the Burrito controller
     enabled: false
@@ -319,6 +331,10 @@ server:
       - secretRef:
           name: burrito-webhook-secret
           optional: true
+    # -- Additional volumes
+    extraVolumes: {}
+    # -- Additional volume mounts
+    extraVolumeMounts: {}
   # -- Service configuration for the Burrito server
   service:
     ports:
@@ -376,6 +392,10 @@ datastore:
       periodSeconds: 20
     # -- Environment variables to pass to the Burrito datastore container
     envFrom: []
+    # -- Additional volumes
+    extraVolumes: {}
+    # -- Additional volume mounts
+    extraVolumeMounts: {}
   # -- Service configuration for the Burrito datastore
   service:
     ports:


### PR DESCRIPTION
Hi!

We use Vault CSI to gather secrets from Hashicorp Vault and it requires to mount a CSI volume to actually get them.

The option `extra*Volumes` was already define for `hermitcrab.yaml` template.