### PR TITLE
feat(datastore): datastore S3 use path style configuration

### DIFF
--- a/deploy/charts/burrito/values.yaml
+++ b/deploy/charts/burrito/values.yaml
@@ -74,6 +74,8 @@ config:
         s3:
           # -- S3 bucket name
           bucket: ""
+          # -- S3 option for bucket name in path instead of as subdomain
+          usePathStyle: false
       # -- Datastore exposed port
       addr: ":8080"
       # -- Datastore hostname, used by controller, server and runner to reach the datastore

--- a/docs/operator-manual/datastore.md
+++ b/docs/operator-manual/datastore.md
@@ -12,6 +12,7 @@ config:
         mock: <false|true> # default: false
         s3:
           bucket: <bucket-name>
+          usePathStyle: <false|true> # default: false
         gcs:
           bucket: <bucket-name>
         azure:

--- a/internal/burrito/config/config.go
+++ b/internal/burrito/config/config.go
@@ -40,7 +40,8 @@ type GCSConfig struct {
 }
 
 type S3Config struct {
-	Bucket string `mapstructure:"bucket"`
+	Bucket       string `mapstructure:"bucket"`
+	UsePathStyle bool   `mapstructure:"usePathStyle"`
 }
 
 type AzureConfig struct {

--- a/internal/datastore/storage/s3/s3.go
+++ b/internal/datastore/storage/s3/s3.go
@@ -24,7 +24,9 @@ func New(config config.S3Config) *S3 {
 	if err != nil {
 		panic(err)
 	}
-	client := storage.NewFromConfig(sdkConfig)
+	client := storage.NewFromConfig(sdkConfig, func(o *storage.Options) {
+		o.UsePathStyle = config.UsePathStyle
+	})
 	return &S3{
 		Config: config,
 		Client: client,


### PR DESCRIPTION
Allow configuration of path style option on AWS S3 SDK.

This allow usage of S3 compatible solutions other than AWS S3.