### PR TITLE
feat: set default runner image in global config

### DIFF
--- a/cmd/controllers/start.go
+++ b/cmd/controllers/start.go
@@ -7,7 +7,9 @@ import (
 	"time"
 
 	"github.com/padok-team/burrito/internal/burrito"
+	"github.com/padok-team/burrito/internal/version"
 	"github.com/spf13/cobra"
+	corev1 "k8s.io/api/core/v1"
 )
 
 func buildControllersStartCmd(app *burrito.App) *cobra.Command {
@@ -41,5 +43,8 @@ func buildControllersStartCmd(app *burrito.App) *cobra.Command {
 	cmd.Flags().StringVar(&app.Config.Controller.HealthProbeBindAddress, "health-probe-bind-address", ":8081", "address to bind the metrics server embedded in the controllers")
 	cmd.Flags().StringVar(&app.Config.Controller.MetricsBindAddress, "metrics-bind-address", ":8080", "address to bind the health probe server embedded in the controllers")
 	cmd.Flags().IntVar(&app.Config.Controller.KubernetesWebhookPort, "kubernetes-webhook-port", 9443, "port used by the validating webhook server embedded in the controllers")
+	cmd.Flags().StringVar(&app.Config.Runner.Image.Repository, "runner-image-repository", "ghcr.io/padok-team/burrito-runner", "Repository of the image to use for the runner pods created by the controller")
+	cmd.Flags().StringVar(&app.Config.Runner.Image.Tag, "runner-image-tag", version.Version, "Tag of the image to use for the runner pods created by the controller")
+	cmd.Flags().StringVar(&app.Config.Runner.Image.PullPolicy, "runner-image-pull-policy", string(corev1.PullIfNotPresent), "Pull policy of the image to use for the runner pods created by the controller")
 	return cmd
 }

--- a/cmd/controllers/start.go
+++ b/cmd/controllers/start.go
@@ -7,9 +7,7 @@ import (
 	"time"
 
 	"github.com/padok-team/burrito/internal/burrito"
-	"github.com/padok-team/burrito/internal/version"
 	"github.com/spf13/cobra"
-	corev1 "k8s.io/api/core/v1"
 )
 
 func buildControllersStartCmd(app *burrito.App) *cobra.Command {
@@ -43,8 +41,5 @@ func buildControllersStartCmd(app *burrito.App) *cobra.Command {
 	cmd.Flags().StringVar(&app.Config.Controller.HealthProbeBindAddress, "health-probe-bind-address", ":8081", "address to bind the metrics server embedded in the controllers")
 	cmd.Flags().StringVar(&app.Config.Controller.MetricsBindAddress, "metrics-bind-address", ":8080", "address to bind the health probe server embedded in the controllers")
 	cmd.Flags().IntVar(&app.Config.Controller.KubernetesWebhookPort, "kubernetes-webhook-port", 9443, "port used by the validating webhook server embedded in the controllers")
-	cmd.Flags().StringVar(&app.Config.Runner.Image.Repository, "runner-image-repository", "ghcr.io/padok-team/burrito-runner", "Repository of the image to use for the runner pods created by the controller")
-	cmd.Flags().StringVar(&app.Config.Runner.Image.Tag, "runner-image-tag", version.Version, "Tag of the image to use for the runner pods created by the controller")
-	cmd.Flags().StringVar(&app.Config.Runner.Image.PullPolicy, "runner-image-pull-policy", string(corev1.PullIfNotPresent), "Pull policy of the image to use for the runner pods created by the controller")
 	return cmd
 }

--- a/deploy/charts/burrito/templates/config.yaml
+++ b/deploy/charts/burrito/templates/config.yaml
@@ -43,6 +43,12 @@ TLS certificates
 {{- $_ := set $config.datastore "certificateSecretName" .Values.datastore.tls.secretName }}
 {{- end }}
 
+{{/*
+Runner
+*/}}
+{{ if eq .Values.config.burrito.runner.image.tag "" }}
+{{- $_ := set $config.runner.image "tag" .Chart.AppVersion }}
+{{- end }}
 
 apiVersion: v1
 kind: ConfigMap

--- a/deploy/charts/burrito/values.yaml
+++ b/deploy/charts/burrito/values.yaml
@@ -95,6 +95,11 @@ config:
     runner:
       # -- Configmap name to store the SSH known hosts in the runner
       sshKnownHostsConfigMapName: burrito-ssh-known-hosts
+      image:
+        # -- Default image to use for runners, can be overriden with spec.OverrideRunnerSpec in repositories and layer definitions
+        repository: ghcr.io/padok-team/burrito
+        tag: "" # By default use Chart's appVersion
+        pullPolicy: Always
 
 hermitcrab:
   # -- Enable/Disable Hermitcrab (terraform provider cache in cluster)

--- a/internal/burrito/config/config.go
+++ b/internal/burrito/config/config.go
@@ -114,8 +114,15 @@ type RunnerConfig struct {
 	Run                        string           `mapstructure:"run"`
 	Repository                 RepositoryConfig `mapstructure:"repository"`
 	SSHKnownHostsConfigMapName string           `mapstructure:"sshKnownHostsConfigMapName"`
+	Image                      ImageConfig      `mapstructure:"image"`
 	RunnerBinaryPath           string           `mapstructure:"runnerBinaryPath"`
 	RepositoryPath             string           `mapstructure:"repositoryPath"`
+}
+
+type ImageConfig struct {
+	Repository string `mapstructure:"repository"`
+	Tag        string `mapstructure:"tag"`
+	PullPolicy string `mapstructure:"pullPolicy"`
 }
 
 type Layer struct {

--- a/internal/burrito/config/config_test.go
+++ b/internal/burrito/config/config_test.go
@@ -44,6 +44,11 @@ func TestConfig_FromYamlFile(t *testing.T) {
 				Name:      "test",
 				Namespace: "default",
 			},
+			Image: config.ImageConfig{
+				Repository: "test-repository",
+				Tag:        "test-tag",
+				PullPolicy: "Always",
+			},
 			Repository: config.RepositoryConfig{
 				SSHPrivateKey: "private-key",
 				Username:      "test",
@@ -130,6 +135,9 @@ func TestConfig_EnvVarOverrides(t *testing.T) {
 	setEnvVar(t, "BURRITO_RUNNER_REPOSITORY_USERNAME", "other-username", &envVarList)
 	setEnvVar(t, "BURRITO_RUNNER_REPOSITORY_PASSWORD", "other-password", &envVarList)
 	setEnvVar(t, "BURRITO_RUNNER_REPOSITORY_SSHPRIVATEKEY", "other-private-key", &envVarList)
+	setEnvVar(t, "BURRITO_RUNNER_IMAGE_REPOSITORY", "other-repository", &envVarList)
+	setEnvVar(t, "BURRITO_RUNNER_IMAGE_TAG", "other-tag", &envVarList)
+	setEnvVar(t, "BURRITO_RUNNER_IMAGE_PULLPOLICY", "Always", &envVarList)
 	// Controller
 	setEnvVar(t, "BURRITO_CONTROLLER_TYPES", "layer,repository", &envVarList)
 	setEnvVar(t, "BURRITO_CONTROLLER_NAMESPACES", "default,burrito,other", &envVarList)
@@ -175,6 +183,11 @@ func TestConfig_EnvVarOverrides(t *testing.T) {
 			Layer: config.Layer{
 				Name:      "other-layer",
 				Namespace: "other-namespace",
+			},
+			Image: config.ImageConfig{
+				Repository: "other-repository",
+				Tag:        "other-tag",
+				PullPolicy: "Always",
 			},
 			Repository: config.RepositoryConfig{
 				SSHPrivateKey: "other-private-key",

--- a/internal/burrito/config/testdata/test-config-1.yaml
+++ b/internal/burrito/config/testdata/test-config-1.yaml
@@ -3,6 +3,10 @@ runner:
   layer:
     name: test
     namespace: default
+  image:
+    repository: test-repository
+    tag: test-tag
+    pullPolicy: Always
   repository:
     sshPrivateKey: "private-key"
     username: "test"

--- a/internal/controllers/terraformrun/pod.go
+++ b/internal/controllers/terraformrun/pod.go
@@ -6,7 +6,6 @@ import (
 
 	configv1alpha1 "github.com/padok-team/burrito/api/v1alpha1"
 	"github.com/padok-team/burrito/internal/burrito/config"
-	"github.com/padok-team/burrito/internal/version"
 	log "github.com/sirupsen/logrus"
 	corev1 "k8s.io/api/core/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
@@ -284,8 +283,8 @@ func defaultPodSpec(config *config.Config, layer *configv1alpha1.TerraformLayer,
 		Containers: []corev1.Container{
 			{
 				Name:            "runner",
-				Image:           fmt.Sprintf("ghcr.io/padok-team/burrito:%s", version.Version),
-				ImagePullPolicy: corev1.PullIfNotPresent,
+				Image:           fmt.Sprintf("%s:%s", config.Runner.Image.Repository, config.Runner.Image.Tag),
+				ImagePullPolicy: corev1.PullPolicy(config.Runner.Image.PullPolicy),
 				Args:            []string{"runner", "start"},
 				VolumeMounts: []corev1.VolumeMount{
 					{


### PR DESCRIPTION
This update adds a configuration parameter to set the default repository, tag, and pull policy for the image used in runner pods.
Previously, to use a custom image for all Burrito pods (often necessary during development), we had to override the image in both the chart's values and the spec.overrideRunnerSpec field of a TerraformLayer or TerraformRepository resource.