### PR TITLE
chore(renovate): update renovate config file

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -1,6 +1,25 @@
 {
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
   "extends": [
-    "local>padok-team/renovate-config"
+    "config:recommended",
+    "docker:pinDigests",
+    ":label(renovate)",
+    ":configMigration",
+    ":semanticPrefixFix",
+    ":separateMultipleMajorReleases",
+    ":automergeDigest",
+    ":automergePatch"
+  ],
+  "packageRules": [
+    {
+      "matchPackagePatterns": [
+        "*"
+      ],
+      "matchUpdateTypes": [
+        "patch"
+      ],
+      "groupName": "all patch dependencies",
+      "groupSlug": "all-patch"
+    }
   ]
 }


### PR DESCRIPTION
Inpired by the [`padok-team/renovate-config`](https://github.com/padok-team/renovate-config/blob/main/default.json) defaults, this Renovate config file is more suited to Burrito, stopping pinning GitHub Actions for example (reducing the load of PRs generated by Renovate).