### PR TITLE
fix(datastore): correct prefix to list with S3 storage

### DIFF
--- a/internal/datastore/storage/s3/s3.go
+++ b/internal/datastore/storage/s3/s3.go
@@ -3,7 +3,9 @@ package s3
 import (
 	"bytes"
 	"context"
+	"fmt"
 	"io"
+	"strings"
 
 	sdk "github.com/aws/aws-sdk-go-v2/config"
 	storage "github.com/aws/aws-sdk-go-v2/service/s3"
@@ -86,7 +88,7 @@ func (a *S3) Delete(key string) error {
 func (a *S3) List(prefix string) ([]string, error) {
 	input := &storage.ListObjectsV2Input{
 		Bucket:    &a.Config.Bucket,
-		Prefix:    &prefix,
+		Prefix:    aws.String(fmt.Sprintf("%s/", strings.TrimPrefix(prefix, "/"))),
 		Delimiter: aws.String("/"),
 	}
 	result, err := a.Client.ListObjectsV2(context.TODO(), input)


### PR DESCRIPTION
According to https://docs.aws.amazon.com/AmazonS3/latest/API/API_ListObjectsV2.html#API_ListObjectsV2_ResponseSyntax, for `ListObjectsV2`, the Prefix must:
* not begins with a `/`
* ends with a `/`

But curently, the used prefix is something like `/layers/<namespace>/<layer>/<run>`.
So we need to transform it like `layers/<namespace>/<layer>/<run>/` to get some list results.


fix https://github.com/padok-team/burrito/issues/332