### PR TITLE
fix(datastore): remove leading slash in objects key

### DIFF
--- a/docs/operator-manual/datastore.md
+++ b/docs/operator-manual/datastore.md
@@ -8,6 +8,7 @@ The Datastore storage backend can be configured using the following yaml configu
 config:
   burrito:
     datastore:
+      skipLeadingSlashInKey: <false|true> # default: false
       storage:
         mock: <false|true> # default: false
         s3:

--- a/internal/burrito/config/config.go
+++ b/internal/burrito/config/config.go
@@ -26,6 +26,7 @@ type DatastoreConfig struct {
 	CertificateSecretName     string        `mapstructure:"certificateSecretName"`
 	Storage                   StorageConfig `mapstructure:"storage"`
 	AuthorizedServiceAccounts []string      `mapstructure:"serviceAccounts"`
+	SkipLeadingSlashInKey     bool          `mapstructure:"skipLeadingSlashInKey"`
 }
 
 type StorageConfig struct {

--- a/internal/datastore/api/api.go
+++ b/internal/datastore/api/api.go
@@ -7,7 +7,7 @@ import (
 
 type API struct {
 	config  *config.Config
-	Storage storage.Storage
+	Storage *storage.Storage
 }
 
 func New(c *config.Config) *API {

--- a/internal/datastore/api/api_test.go
+++ b/internal/datastore/api/api_test.go
@@ -10,6 +10,7 @@ import (
 	"github.com/labstack/echo/v4"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
+	"github.com/padok-team/burrito/internal/burrito/config"
 	"github.com/padok-team/burrito/internal/datastore/api"
 	"github.com/padok-team/burrito/internal/datastore/storage"
 	"github.com/padok-team/burrito/internal/datastore/storage/mock"
@@ -28,8 +29,9 @@ func TestDatastoreAPI(t *testing.T) {
 
 var _ = BeforeSuite(func() {
 	logf.SetLogger(zap.New(zap.WriteTo(GinkgoWriter), zap.UseDevMode(true)))
-	s := storage.Storage{
+	s := &storage.Storage{
 		Backend: mock.New(),
+		Config:  config.TestConfig(),
 	}
 	API = &api.API{}
 	API.Storage = s

--- a/internal/datastore/datastore.go
+++ b/internal/datastore/datastore.go
@@ -31,7 +31,7 @@ func New(c *config.Config) *Datastore {
 
 func (s *Datastore) Exec() {
 	s.API = api.New(s.Config)
-	s.API.Storage = storage.New(*s.Config)
+	s.API.Storage = storage.New(s.Config)
 	authz := authz.NewAuthz()
 	for _, sa := range s.Config.Datastore.AuthorizedServiceAccounts {
 		l := strings.Split(sa, "/")

--- a/internal/datastore/storage/azure/azure.go
+++ b/internal/datastore/storage/azure/azure.go
@@ -18,11 +18,11 @@ import (
 type Azure struct {
 	// Azure Blob Storage client
 	Client *storage.Client
-	Config config.AzureConfig
+	Config *config.AzureConfig
 }
 
 // New creates a new Azure Blob Storage client
-func New(config config.AzureConfig) *Azure {
+func New(config *config.AzureConfig) *Azure {
 	credential, err := identity.NewDefaultAzureCredential(nil)
 	if err != nil {
 		panic(err)
@@ -33,6 +33,7 @@ func New(config config.AzureConfig) *Azure {
 	}
 	return &Azure{
 		Client: client,
+		Config: config,
 	}
 }
 

--- a/internal/datastore/storage/gcs/gcs.go
+++ b/internal/datastore/storage/gcs/gcs.go
@@ -13,18 +13,18 @@ import (
 type GCS struct {
 	// GCS Blob Storage client
 	Client *storage.Client
-	Config config.GCSConfig
+	Config *config.GCSConfig
 }
 
 // New creates a new Google Cloud Storage client
-func New(config config.GCSConfig) *GCS {
+func New(config *config.GCSConfig) *GCS {
 	client, err := storage.NewClient(context.Background())
 	if err != nil {
 		panic(err)
 	}
 	return &GCS{
-		Config: config,
 		Client: client,
+		Config: config,
 	}
 }
 

--- a/internal/datastore/storage/s3/s3.go
+++ b/internal/datastore/storage/s3/s3.go
@@ -5,7 +5,6 @@ import (
 	"context"
 	"fmt"
 	"io"
-	"strings"
 
 	sdk "github.com/aws/aws-sdk-go-v2/config"
 	storage "github.com/aws/aws-sdk-go-v2/service/s3"
@@ -15,13 +14,13 @@ import (
 
 // Implements Storage interface using AWS S3
 type S3 struct {
-	// GCS Blob Storage client
+	// S3 Blob Storage client
 	Client *storage.Client
-	Config config.S3Config
+	Config *config.S3Config
 }
 
 // New creates a new AWS S3 client
-func New(config config.S3Config) *S3 {
+func New(config *config.S3Config) *S3 {
 	sdkConfig, err := sdk.LoadDefaultConfig(context.Background())
 	if err != nil {
 		panic(err)
@@ -30,8 +29,8 @@ func New(config config.S3Config) *S3 {
 		o.UsePathStyle = config.UsePathStyle
 	})
 	return &S3{
-		Config: config,
 		Client: client,
+		Config: config,
 	}
 }
 
@@ -88,7 +87,7 @@ func (a *S3) Delete(key string) error {
 func (a *S3) List(prefix string) ([]string, error) {
 	input := &storage.ListObjectsV2Input{
 		Bucket:    &a.Config.Bucket,
-		Prefix:    aws.String(fmt.Sprintf("%s/", strings.TrimPrefix(prefix, "/"))),
+		Prefix:    aws.String(fmt.Sprintf("%s/", prefix)),
 		Delimiter: aws.String("/"),
 	}
 	result, err := a.Client.ListObjectsV2(context.TODO(), input)

--- a/internal/datastore/storage/storage_test.go
+++ b/internal/datastore/storage/storage_test.go
@@ -1,0 +1,53 @@
+package storage_test
+
+import (
+	"testing"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	"github.com/padok-team/burrito/internal/burrito/config"
+	"github.com/padok-team/burrito/internal/datastore/storage"
+	"github.com/padok-team/burrito/internal/datastore/storage/mock"
+	logf "sigs.k8s.io/controller-runtime/pkg/log"
+	"sigs.k8s.io/controller-runtime/pkg/log/zap"
+)
+
+var Storage *storage.Storage
+
+func TestStorage(t *testing.T) {
+	RegisterFailHandler(Fail)
+
+	RunSpecs(t, "Storage Suite")
+}
+
+var _ = BeforeSuite(func() {
+	logf.SetLogger(zap.New(zap.WriteTo(GinkgoWriter), zap.UseDevMode(true)))
+	s := storage.Storage{
+		Backend: mock.New(),
+		Config:  config.TestConfig(),
+	}
+	Storage = &s
+})
+
+var _ = Describe("Storage", func() {
+	Describe("Keys", func() {
+		Describe("When skip leading slash in key is disabled", func() {
+			It("should return the key with a leading slash", func() {
+				key := Storage.ComputePlanKey("namespace", "layer", "run", "attempt", "format")
+				Expect(key).Should(HavePrefix("/"))
+			})
+		})
+		Describe("When skip leading slash in key is enabled", func() {
+			It("should return the key without a leading slash", func() {
+				testConfig := config.TestConfig()
+				testConfig.Datastore.SkipLeadingSlashInKey = true
+				storage := storage.Storage{
+					Backend: mock.New(),
+					Config:  testConfig,
+				}
+				key := storage.ComputePlanKey("namespace", "layer", "run", "attempt", "format")
+				Expect(key).ShouldNot(HavePrefix("/"))
+			})
+		})
+	})
+})


### PR DESCRIPTION
Add new datastore config option `skipLeadingSlashInKey` to remove leading slash in keys.

I leave default (`false`) value to keep current behaviour.
But I think it should be `true` because it don't make sense to have a leading slash in keys (see https://github.com/padok-team/burrito/issues/332#issuecomment-2450280813 for details).

Also rework pointer usage among datastore packages.
