### PR TITLE
doc: fix example file after v0.5.0 update

### DIFF
--- a/docs/examples/terraform-repository.yaml
+++ b/docs/examples/terraform-repository.yaml
@@ -6,3 +6,5 @@ metadata:
 spec:
   repository:
     url: https://github.com/padok-team/burrito-examples
+  terraform:
+    enabled: true


### PR DESCRIPTION
Example files does not reflect the change in v0.5.0. The documentation refers to the parameter terraform.enabled = true but the file used with kubectl apply does not reflect this change.