### PR TITLE
feat: don't overwrite datastore serviceAccounts in the config

### DIFF
--- a/deploy/charts/burrito/templates/config.yaml
+++ b/deploy/charts/burrito/templates/config.yaml
@@ -14,6 +14,7 @@ Tenant Namespaces
 {{/*
 Datastore Authorized Service Accounts
 */}}
+{{- if not $config.datastore.serviceAccounts }}
 {{- $datastoreAuthorizedServiceAccounts := list }}
 {{- range $tenant := .Values.tenants }}
 {{- range $sa := $tenant.serviceAccounts }}
@@ -26,6 +27,7 @@ Datastore Authorized Service Accounts
 {{- $server := printf "%s/%s" .Release.Namespace "burrito-server" }}
 {{- $datastoreAuthorizedServiceAccounts = append $datastoreAuthorizedServiceAccounts $server }}
 {{- $_ := set $config.datastore "serviceAccounts" $datastoreAuthorizedServiceAccounts }}
+{{- end }}
 
 {{/*
 TLS certificates


### PR DESCRIPTION
config.datastore.serviceAccounts is always populated with:
- namespace/burrito-server
- namespace/burrito-controllers

You have no option to override this value.

This change is meant to be fix this behaviour so you can provide your custom service accounts for the datastore pod