### PR TITLE
fix(api): override tolerations instead of merging them

### DIFF
--- a/api/v1alpha1/common.go
+++ b/api/v1alpha1/common.go
@@ -90,7 +90,7 @@ func GetTerragruntVersion(repository *TerraformRepository, layer *TerraformLayer
 
 func GetOverrideRunnerSpec(repository *TerraformRepository, layer *TerraformLayer) OverrideRunnerSpec {
 	return OverrideRunnerSpec{
-		Tolerations:  mergeTolerations(repository.Spec.OverrideRunnerSpec.Tolerations, layer.Spec.OverrideRunnerSpec.Tolerations),
+		Tolerations:  overrideTolerations(repository.Spec.OverrideRunnerSpec.Tolerations, layer.Spec.OverrideRunnerSpec.Tolerations),
 		NodeSelector: mergeMaps(repository.Spec.OverrideRunnerSpec.NodeSelector, layer.Spec.OverrideRunnerSpec.NodeSelector),
 		Metadata: MetadataOverride{
 			Annotations: mergeMaps(repository.Spec.OverrideRunnerSpec.Metadata.Annotations, layer.Spec.OverrideRunnerSpec.Metadata.Annotations),
@@ -274,20 +274,13 @@ func mergeVolumes(a, b []corev1.Volume) []corev1.Volume {
 	return result
 }
 
-func mergeTolerations(a, b []corev1.Toleration) []corev1.Toleration {
-	result := []corev1.Toleration{}
-	tempMap := map[string]corev1.Toleration{}
+func overrideTolerations(a, b []corev1.Toleration) []corev1.Toleration {
+	result := b
 
-	for _, elt := range a {
-		tempMap[elt.Key] = elt
-	}
-	for _, elt := range b {
-		tempMap[elt.Key] = elt
+	if len(result) == 0 {
+		result = a
 	}
 
-	for _, v := range tempMap {
-		result = append(result, v)
-	}
 	return result
 }
 

--- a/api/v1alpha1/common_test.go
+++ b/api/v1alpha1/common_test.go
@@ -638,7 +638,7 @@ func TestOverrideRunnerSpec(t *testing.T) {
 		expectedSpec configv1alpha1.OverrideRunnerSpec
 	}{
 		{
-			"MergeTolerations",
+			"OverrideTolerations",
 			&configv1alpha1.TerraformRepository{
 				Spec: configv1alpha1.TerraformRepositorySpec{
 					OverrideRunnerSpec: configv1alpha1.OverrideRunnerSpec{
@@ -677,11 +677,6 @@ func TestOverrideRunnerSpec(t *testing.T) {
 			},
 			configv1alpha1.OverrideRunnerSpec{
 				Tolerations: []corev1.Toleration{
-					{
-						Key:    "only-exists-in-repository",
-						Value:  "true",
-						Effect: "NoSchedule",
-					},
 					{
 						Key:    "does-not-exists-in-layer",
 						Value:  "false",
@@ -763,6 +758,116 @@ func TestOverrideRunnerSpec(t *testing.T) {
 						Key:    "only-exists-in-layer",
 						Value:  "true",
 						Effect: "NoSchedule",
+					},
+				},
+			},
+		},
+		{
+			"TolerationsWithSameKeyButDifferentValuesExistInBoth",
+			&configv1alpha1.TerraformRepository{
+				Spec: configv1alpha1.TerraformRepositorySpec{
+					OverrideRunnerSpec: configv1alpha1.OverrideRunnerSpec{
+						Tolerations: []corev1.Toleration{
+							{
+								Key:    "exists-in-both",
+								Value:  "true",
+								Effect: "NoExecute",
+							},
+						},
+					},
+				},
+			},
+			&configv1alpha1.TerraformLayer{
+				Spec: configv1alpha1.TerraformLayerSpec{
+					OverrideRunnerSpec: configv1alpha1.OverrideRunnerSpec{
+						Tolerations: []corev1.Toleration{
+							{
+								Key:    "exists-in-both",
+								Value:  "false",
+								Effect: "NoExecute",
+							},
+						},
+					},
+				},
+			},
+			configv1alpha1.OverrideRunnerSpec{
+				Tolerations: []corev1.Toleration{
+					{
+						Key:    "exists-in-both",
+						Value:  "false",
+						Effect: "NoExecute",
+					},
+				},
+			},
+		},
+		{
+			"TolerationsWithSameKeyButDifferentValuesOnlyInRepository",
+			&configv1alpha1.TerraformRepository{
+				Spec: configv1alpha1.TerraformRepositorySpec{
+					OverrideRunnerSpec: configv1alpha1.OverrideRunnerSpec{
+						Tolerations: []corev1.Toleration{
+							{
+								Key:    "same-key",
+								Value:  "value-1",
+								Effect: "NoExecute",
+							},
+							{
+								Key:    "same-key",
+								Value:  "value-2",
+								Effect: "NoExecute",
+							},
+						},
+					},
+				},
+			},
+			&configv1alpha1.TerraformLayer{},
+			configv1alpha1.OverrideRunnerSpec{
+				Tolerations: []corev1.Toleration{
+					{
+						Key:    "same-key",
+						Value:  "value-1",
+						Effect: "NoExecute",
+					},
+					{
+						Key:    "same-key",
+						Value:  "value-2",
+						Effect: "NoExecute",
+					},
+				},
+			},
+		},
+		{
+			"TolerationsWithSameKeyButDifferentValuesOnlyInLayer",
+			&configv1alpha1.TerraformRepository{},
+			&configv1alpha1.TerraformLayer{
+				Spec: configv1alpha1.TerraformLayerSpec{
+					OverrideRunnerSpec: configv1alpha1.OverrideRunnerSpec{
+						Tolerations: []corev1.Toleration{
+							{
+								Key:    "same-key",
+								Value:  "value-1",
+								Effect: "NoExecute",
+							},
+							{
+								Key:    "same-key",
+								Value:  "value-2",
+								Effect: "NoExecute",
+							},
+						},
+					},
+				},
+			},
+			configv1alpha1.OverrideRunnerSpec{
+				Tolerations: []corev1.Toleration{
+					{
+						Key:    "same-key",
+						Value:  "value-1",
+						Effect: "NoExecute",
+					},
+					{
+						Key:    "same-key",
+						Value:  "value-2",
+						Effect: "NoExecute",
 					},
 				},
 			},


### PR DESCRIPTION
fix issue #313

Breaking changes: terraform layer tolerations (if exist) override completely terraform repository tolerations.
Allows multiple tolerations with same key but different values.