### PR TITLE
feat(chart): add a default service account for runner pods

### DIFF
--- a/deploy/charts/burrito/templates/tenant.yaml
+++ b/deploy/charts/burrito/templates/tenant.yaml
@@ -13,6 +13,13 @@ spec:
   - kubernetes
 ---
 {{- end }}
+# Default service account for running Burrito pods, this makes it optional to create at least one service account for each tenant
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: burrito-runner
+  namespace: {{ $tenant.namespace.name }}
+---
 {{- range $serviceAccount := .serviceAccounts }}
 apiVersion: v1
 kind: ServiceAccount

--- a/docs/operator-manual/multi-tenant-architecture.md
+++ b/docs/operator-manual/multi-tenant-architecture.md
@@ -55,7 +55,7 @@ tenants:
 
 ### 2. Configure service accounts
 
-Each service account created in a tenant is binded to the `burrito-runner` ClusterRole, it is a basic role with the required permissions for a burrito runner pod to work properly.
+Each service account created in a tenant is bound to the `burrito-runner` ClusterRole, it is a basic role with the required permissions for a burrito runner pod to work properly.
 
 You can add additional role bindings to the service accounts if you need special permissions in the cluster (e.g. a Terraform layer deploying to Kubernetes) as well as annotations and labels (e.g. assume a role on a cloud provider).
 


### PR DESCRIPTION
The default service account used for runner pods is called `burrito-runner`(see `internal/controllers/terraformrun/pod.go`).
Currently, you either:
- Create this specific service account in tenants
- Create a service account with an other name, and reference it with `overrideRunnerSpec.serviceAccountName` in layers and/or repositories