### PR TITLE
fix(datastore): add config in Azure struct

### DIFF
--- a/internal/datastore/storage/azure/azure.go
+++ b/internal/datastore/storage/azure/azure.go
@@ -33,6 +33,7 @@ func New(config config.AzureConfig) *Azure {
 	}
 	return &Azure{
 		Client: client,
+		Config: config,
 	}
 }
 


### PR DESCRIPTION
Add config in the Azure struct.
Needed to use the right container. Without that, the datastore writes in a "layers" blob container and the list of the blob files doesn't work.