### PR TITLE
chore(ui): separate renovate and CI/CD

### DIFF
--- a/.github/workflows/ci-frontend.yaml
+++ b/.github/workflows/ci-frontend.yaml
@@ -1,0 +1,58 @@
+name: Continuous Integration for Frontend
+
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+    branches:
+      - main
+    paths:
+      - "ui/**"
+
+env:
+  NODE_VERSION: 22
+
+jobs:
+  build:
+    name: Build UI
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: "${{ env.NODE_VERSION }}"
+      - name: Run install
+        uses: borales/actions-yarn@v5
+        with:
+          cmd: install
+          dir: ui
+      - name: Run build
+        uses: borales/actions-yarn@v5
+        with:
+          cmd: build
+          dir: ui
+
+  lint:
+    name: Lint TS
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: "${{ env.NODE_VERSION }}"
+      - name: Run install
+        uses: borales/actions-yarn@v5
+        with:
+          cmd: install
+          dir: ui
+      - name: Run eslint
+        uses: borales/actions-yarn@v5
+        with:
+          cmd: lint
+          dir: ui
+      - name: Run prettier
+        uses: borales/actions-yarn@v5
+        with:
+          cmd: format-check
+          dir: ui

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -73,29 +73,5 @@ jobs:
           version: v1.63
           args: --timeout=5m
 
-  lint-ts:
-    name: Lint TS
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-node@v4
-        with:
-          node-version: 20
-      - name: Run install
-        uses: borales/actions-yarn@v5
-        with:
-          cmd: install
-          dir: ui
-      - name: Run eslint
-        uses: borales/actions-yarn@v5
-        with:
-          cmd: lint
-          dir: ui
-      - name: Run prettier
-        uses: borales/actions-yarn@v5
-        with:
-          cmd: format-check
-          dir: ui
-
   build-and-push:
     uses: ./.github/workflows/build-and-push.yaml

--- a/renovate.json
+++ b/renovate.json
@@ -11,14 +11,29 @@
   ],
   "packageRules": [
     {
-      "matchUpdateTypes": ["patch"],
-      "groupName": "all patch dependencies",
-      "groupSlug": "all-patch",
-      "matchPackageNames": ["*"]
+      "matchFileNames": [
+        "ui/**"
+      ],
+      "groupName": "ui dependencies",
+      "groupSlug": "ui-dependencies"
     },
     {
-      "matchManagers": ["dockerfile"],
-      "matchUpdateTypes": ["digest"],
+      "matchUpdateTypes": [
+        "patch"
+      ],
+      "groupName": "all patch dependencies",
+      "groupSlug": "all-patch",
+      "matchPackageNames": [
+        "*"
+      ]
+    },
+    {
+      "matchManagers": [
+        "dockerfile"
+      ],
+      "matchUpdateTypes": [
+        "digest"
+      ],
       "pinDigests": true,
       "commitMessagePrefix": "chore(docker):",
       "commitMessageAction": "pin digests",


### PR DESCRIPTION
This PR reduces Renovate PRs on frontend dependencies (all deps will be in one PR) and splits the CI between the operator and the frontend to reduce CI times