### PR TITLE
fix(docker): reduce binary size + speed up build

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -45,7 +45,7 @@ COPY --from=builder-ui /workspace/dist internal/server/dist
 # by leaving it empty we can ensure that the container and binary shipped on it will have the same platform.
 ARG VERSION
 ENV GOCACHE=/root/.cache/go-build
-RUN --mount=type=cache,target=/root/.cache/go-build CGO_ENABLED=0 GOOS=${TARGETOS:-linux} GOARCH=${TARGETARCH} go build -a \
+RUN --mount=type=cache,target=/root/.cache/go-build CGO_ENABLED=0 GOOS=${TARGETOS:-linux} GOARCH=${TARGETARCH} go build \
   -ldflags="-w -s \
   -X ${PACKAGE}/internal/version.Version=${VERSION} \
   -X ${PACKAGE}/internal/version.CommitHash=${COMMIT_HASH} \

--- a/Dockerfile
+++ b/Dockerfile
@@ -46,7 +46,7 @@ COPY --from=builder-ui /workspace/dist internal/server/dist
 ARG VERSION
 ENV GOCACHE=/root/.cache/go-build
 RUN --mount=type=cache,target=/root/.cache/go-build CGO_ENABLED=0 GOOS=${TARGETOS:-linux} GOARCH=${TARGETARCH} go build -a \
-  -ldflags="\
+  -ldflags="-w -s \
   -X ${PACKAGE}/internal/version.Version=${VERSION} \
   -X ${PACKAGE}/internal/version.CommitHash=${COMMIT_HASH} \
   -X ${PACKAGE}/internal/version.BuildTimestamp=${BUILD_TIMESTAMP}" \


### PR DESCRIPTION
- Use `-s -w` to strip debug symbols. On Linux/ARM64 `burrito` binary goes from ~120MB to ~80MB.
- Remove `-a` option to `go build` because it was rebuilding all the packages from scratch, thus not using the cache. This will speed up builds on local machines.