### PR TITLE
feat(ui): limit width of layer cards to a third of the grid

### DIFF
--- a/ui/src/pages/Layers.tsx
+++ b/ui/src/pages/Layers.tsx
@@ -390,7 +390,7 @@ const Layers: React.FC = () => {
         `}
       >
         {view === 'grid' ? (
-          <div className="grid grid-cols-[repeat(auto-fit,_minmax(400px,_1fr))] p-6 gap-6">
+          <div className="grid grid-cols-[repeat(auto-fit,_minmax(400px,calc(100%/3)))] p-6 gap-6">
             {layersQuery.isLoading ? (
               Array.from({ length: 100 }).map((_, index) => (
                 <CardLoader key={index} variant={theme} />


### PR DESCRIPTION
The layer cards are currently stretched on the whole screen on the main page. (happens when you have < 3 layers)
It's now limited to a third of the screen to make it more consistent with the view displayed when there are >= 3 layers
1 layer:
<img width="1537" alt="image" src="https://github.com/user-attachments/assets/e0c23619-a9de-41a8-ba96-97a3a7d0f03a" />

2 layers:
<img width="1537" alt="image" src="https://github.com/user-attachments/assets/7e8e468b-8f41-4bd2-93eb-8a53da18ba36" />

Small screen size:
<img width="534" alt="image" src="https://github.com/user-attachments/assets/2f5ce9ec-82f5-4f07-a754-d9e652ed40a9" />

