### PR TITLE
chore(ci): only run Golang CI on specific changes

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -7,6 +7,11 @@ on:
   pull_request:
     branches:
       - main
+    paths:
+      - "**.go"
+      - "go.mod"
+      - "go.sum"
+      - "Dockerfile"
 
 permissions:
   packages: write


### PR DESCRIPTION
This will save time on Renovate PRs fixing other areas that Go dependencies (for example UI dependencies)