### PR TITLE
fix(datastore): handle not found errors from azure, s3 and gcs

### DIFF
--- a/internal/datastore/storage/azure/azure.go
+++ b/internal/datastore/storage/azure/azure.go
@@ -84,6 +84,12 @@ func (a *Azure) Set(key string, value []byte, ttl int) error {
 
 func (a *Azure) Delete(key string) error {
 	_, err := a.Client.DeleteBlob(context.Background(), a.Config.Container, key, nil)
+	if bloberror.HasCode(err, bloberror.BlobNotFound) {
+		return &errors.StorageError{
+			Err: err,
+			Nil: true,
+		}
+	}
 	if err != nil {
 		return &errors.StorageError{
 			Err: err,


### PR DESCRIPTION
For some storage backend implementations, "not found" errors were not implemented for Get and Check operations resulting in unwanted 500 error from the Datastore API.