### PR TITLE
fix(chart): add rbac for default SA + server in each tenant

### DIFF
--- a/deploy/charts/burrito/templates/config.yaml
+++ b/deploy/charts/burrito/templates/config.yaml
@@ -15,12 +15,14 @@ Tenant Namespaces
 Datastore Authorized Service Accounts
 */}}
 {{- $datastoreAuthorizedServiceAccounts := list }}
-{{- range $tenant := .Values.tenants }}
-{{- range $sa := $tenant.serviceAccounts }}
-{{- $serviceAccount := printf "%s/%s" $tenant.namespace.name $sa.name }}
-{{- $datastoreAuthorizedServiceAccounts = append $datastoreAuthorizedServiceAccounts $serviceAccount }}
-{{- end }}
-{{- end }}
+  {{- range $tenant := .Values.tenants }}
+    {{- range $sa := $tenant.serviceAccounts }}
+      {{- $serviceAccount := printf "%s/%s" $tenant.namespace.name $sa.name }}
+      {{- $datastoreAuthorizedServiceAccounts = append $datastoreAuthorizedServiceAccounts $serviceAccount }}
+    {{- end }}
+    # adding also default `burrito-runner` serviceaccount created in each tenant
+    {{- $datastoreAuthorizedServiceAccounts = append $datastoreAuthorizedServiceAccounts (printf "%s/burrito-runner" $tenant.namespace.name) }}
+  {{- end }}
 {{- $controller := printf "%s/%s" .Release.Namespace "burrito-controllers" }}
 # check if the service account is already in the list, to prevent adding it multiple times if the config rerenders
 {{- if not (has $controller $config.datastore.serviceAccounts) }}
@@ -30,7 +32,7 @@ Datastore Authorized Service Accounts
 {{- if not (has $server $config.datastore.serviceAccounts) }}
   {{- $datastoreAuthorizedServiceAccounts = append $datastoreAuthorizedServiceAccounts $server }}
 {{- end }}
-{{- $_ := set $config.datastore "serviceAccounts" (concat $datastoreAuthorizedServiceAccounts $config.datastore.serviceAccounts) }}
+{{- $_ := set $config.datastore "serviceAccounts" ((concat $datastoreAuthorizedServiceAccounts $config.datastore.serviceAccounts) | uniq) }}
 
 {{/*
 TLS certificates

--- a/deploy/charts/burrito/templates/tenant.yaml
+++ b/deploy/charts/burrito/templates/tenant.yaml
@@ -40,6 +40,54 @@ metadata:
   name: burrito-runner
   namespace: {{ $tenant.namespace.name }}
 ---
+# Role binding for the default service account
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: burrito-runner
+  namespace: {{ $tenant.namespace.name }}
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: burrito-runner
+subjects:
+- kind: ServiceAccount
+  name: burrito-runner
+  namespace: {{ $tenant.namespace.name }}
+---
+# Role and RoleBinding for burrito-server to access this tenant's secrets (webhook secret)
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: secret-access
+  labels:
+    {{- toYaml $metadataControllers.labels | nindent 4 }}
+  annotations:
+    {{- toYaml $metadataControllers.annotations | nindent 4 }}
+  namespace: {{ $tenant.namespace.name }}
+rules:
+- apiGroups: [""]
+  resources: ["secrets"]
+  verbs: ["get", "list", "watch"]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: burrito-server-secret-access
+  labels:
+    {{- toYaml $metadataControllers.labels | nindent 4 }}
+  annotations:
+    {{- toYaml $metadataControllers.annotations | nindent 4 }}
+  namespace: {{ $tenant.namespace.name }}
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: secret-access
+subjects:
+- kind: ServiceAccount
+  name: burrito-server
+  namespace: {{ $.Release.Namespace }}
+---
 {{- range $serviceAccount := .serviceAccounts }}
 apiVersion: v1
 kind: ServiceAccount
@@ -66,34 +114,6 @@ subjects:
 - kind: ServiceAccount
   name: {{ $serviceAccount.name }}
   namespace: {{ $tenant.namespace.name }}
----
-apiVersion: rbac.authorization.k8s.io/v1
-kind: Role
-metadata:
-  name: secret-access
-  labels:
-    app: burrito
-  namespace: {{ $tenant.namespace.name }}
-rules:
-- apiGroups: [""]
-  resources: ["secrets"]
-  verbs: ["get", "list", "watch"]
----
-apiVersion: rbac.authorization.k8s.io/v1
-kind: RoleBinding
-metadata:
-  name: burrito-server-secret-access
-  labels:
-    app: burrito
-  namespace: {{ $tenant.namespace.name }}
-roleRef:
-  apiGroup: rbac.authorization.k8s.io
-  kind: Role
-  name: secret-access
-subjects:
-- kind: ServiceAccount
-  name: burrito-server
-  namespace: {{ $.Release.Namespace }}
 ---
 {{- range $additionalRoleBinding := $serviceAccount.additionalRoleBindings }}
 apiVersion: rbac.authorization.k8s.io/v1

--- a/deploy/charts/burrito/values-dev.yaml
+++ b/deploy/charts/burrito/values-dev.yaml
@@ -18,5 +18,3 @@ tenants:
   - namespace:
       create: true
       name: "burrito-project"
-    serviceAccounts:
-      - name: burrito-runner

--- a/deploy/charts/burrito/values.yaml
+++ b/deploy/charts/burrito/values.yaml
@@ -421,7 +421,7 @@ datastore:
             kind: Issuer
 
 # -- List of tenants to create to manage Terraform resources
-tenants:
+tenants: []
 # - namespace:
 #     create: true
 #     name: "burrito-project-1"


### PR DESCRIPTION
Fixes #512 

In tenants where no custom service accounts were defined in the Helm chart:
- the default `burrito-runner` ServiceAccount was missing a RoleBinding for interacting with Repos/Layers + an entry in the authorized SA list of the datastore
- the `burrito-system/burrito-server` SA was missing a Role+RoleBinding for reading secrets in this tenant (mandatory for reading webhook secret in the new Git provider config)