### PR TITLE
docs: update domain name to docs.burrito.tf

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,3 +1,3 @@
 # Contributing
 
-Check out the [contributing guide](https://padok-team.github.io/burrito/contributing/) to know how to contribute to Burrito.
+Check out the [contributing guide](https://docs.burrito.tf/contributing/) to know how to contribute to Burrito.

--- a/README.md
+++ b/README.md
@@ -35,13 +35,13 @@ Finally, currently, there is no easy way to navigate your Terraform state to tru
 
 ## Documentation
 
-To learn more about burrito [go to the complete documentation](https://padok-team.github.io/burrito/).
+To learn more about burrito [go to the complete documentation](https://docs.burrito.tf).
 
 ## Community
 
 ### Contribution, Discussion and Support
 
-Please read our [Contribution Guide](https://padok-team.github.io/burrito/contributing/) for more information on how to get involved.
+Please read our [Contribution Guide](https://docs.burrito.tf/contributing/) for more information on how to get involved.
 
 Current maintainers:
 

--- a/deploy/charts/burrito/values.yaml
+++ b/deploy/charts/burrito/values.yaml
@@ -4,7 +4,7 @@
 # install: true
 
 # Burrito configuration
-## Ref: https://padok-team.github.io/burrito/operator-manual/advanced-configuration/
+## Ref: https://docs.burrito.tf/operator-manual/advanced-configuration/
 config:
   # -- Create ConfigMap with Burrito configuration
   create: true

--- a/docs/CNAME
+++ b/docs/CNAME
@@ -1,0 +1,1 @@
+docs.burrito.tf

--- a/docs/contributing.md
+++ b/docs/contributing.md
@@ -187,4 +187,4 @@ It is strongly recommended to create a GitHub token with no specific rights to b
 ## Additional Resources
 
 - [Controller-runtime documentation](https://pkg.go.dev/sigs.k8s.io/controller-runtime@v0.13.0) (Burrito heavily relies on this package)
-- [Burrito documentation](https://padok-team.github.io/burrito/)
+- [Burrito documentation](https://docs.burrito.tf/)

--- a/docs/operator-manual/pr-mr-workflow.md
+++ b/docs/operator-manual/pr-mr-workflow.md
@@ -62,7 +62,7 @@ You can create and register GitHub Apps in your personal GitHub account or in an
 Follow the instructions in the GitHub documentation on [Creating a GitHub App](https://docs.github.com/en/apps/creating-github-apps/registering-a-github-app/registering-a-github-app). Populate the settings as follows:
 
 - **GitHub App Name**: Choose a name for your GitHub App. For example, something featuring `burrito`.
-- **Homepage URL**: Enter <https://padok-team.github.io/burrito>.
+- **Homepage URL**: Enter <https://docs.burrito.tf>.
 - **Webhook**: Unselect Active. The app doesn't use this webhook events mechanism at the moment.
 - **Permissions**: Configure the following **Repository Permissions**:
     - **Metadata**: Select Read-only.

--- a/internal/controllers/terraformpullrequest/controller.go
+++ b/internal/controllers/terraformpullrequest/controller.go
@@ -182,7 +182,7 @@ func (r *Reconciler) initializeProvider(ctx context.Context, repository *configv
 
 // This function initializes default providers for the controller if user has provided legacy configuration
 func (r *Reconciler) initializeDefaultProviders() error {
-	log.Warningf("deprecated GitHub/GitLab configuration found. please configure repositories with secrets instead. See https://padok-team.github.io/burrito/operator-manual/git-authentication/#repository-secret for more information.")
+	log.Warningf("deprecated GitHub/GitLab configuration found. please configure repositories with secrets instead. See https://docs.burrito.tf/operator-manual/git-authentication/#repository-secret for more information.")
 	var config = gitprovider.Config{
 		AppID:             r.Config.Controller.GithubConfig.AppId,
 		AppInstallationID: r.Config.Controller.GithubConfig.InstallationId,


### PR DESCRIPTION
Domain name is already setup in repository's setting. This PR replaces all references of all domain to the new one.