### PR TITLE
feat: add setting to limit the number of concurrent runner pods

### DIFF
--- a/api/v1alpha1/terraformrepository_types.go
+++ b/api/v1alpha1/terraformrepository_types.go
@@ -37,7 +37,7 @@ type TerraformRepositorySpec struct {
 	RemediationStrategy     RemediationStrategy           `json:"remediationStrategy,omitempty"`
 	OverrideRunnerSpec      OverrideRunnerSpec            `json:"overrideRunnerSpec,omitempty"`
 	RunHistoryPolicy        RunHistoryPolicy              `json:"runHistoryPolicy,omitempty"`
-	MaxConcurrentRunnerPods int                           `json:"maxConcurrentRuns,omitempty"`
+	MaxConcurrentRunnerPods int                           `json:"maxConcurrentRunnerPods,omitempty"`
 	SyncWindows             []SyncWindow                  `json:"syncWindows,omitempty"`
 }
 type TerraformRepositoryRepository struct {

--- a/api/v1alpha1/terraformrepository_types.go
+++ b/api/v1alpha1/terraformrepository_types.go
@@ -30,14 +30,15 @@ type TerraformRepositorySpec struct {
 	// INSERT ADDITIONAL SPEC FIELDS - desired state of cluster
 	// Important: Run "make" to regenerate code after modifying this file
 
-	Repository          TerraformRepositoryRepository `json:"repository,omitempty"`
-	TerraformConfig     TerraformConfig               `json:"terraform,omitempty"`
-	TerragruntConfig    TerragruntConfig              `json:"terragrunt,omitempty"`
-	OpenTofuConfig      OpenTofuConfig                `json:"opentofu,omitempty"`
-	RemediationStrategy RemediationStrategy           `json:"remediationStrategy,omitempty"`
-	OverrideRunnerSpec  OverrideRunnerSpec            `json:"overrideRunnerSpec,omitempty"`
-	RunHistoryPolicy    RunHistoryPolicy              `json:"runHistoryPolicy,omitempty"`
-	SyncWindows         []SyncWindow                  `json:"syncWindows,omitempty"`
+	Repository              TerraformRepositoryRepository `json:"repository,omitempty"`
+	TerraformConfig         TerraformConfig               `json:"terraform,omitempty"`
+	TerragruntConfig        TerragruntConfig              `json:"terragrunt,omitempty"`
+	OpenTofuConfig          OpenTofuConfig                `json:"opentofu,omitempty"`
+	RemediationStrategy     RemediationStrategy           `json:"remediationStrategy,omitempty"`
+	OverrideRunnerSpec      OverrideRunnerSpec            `json:"overrideRunnerSpec,omitempty"`
+	RunHistoryPolicy        RunHistoryPolicy              `json:"runHistoryPolicy,omitempty"`
+	MaxConcurrentRunnerPods int                           `json:"maxConcurrentRuns,omitempty"`
+	SyncWindows             []SyncWindow                  `json:"syncWindows,omitempty"`
 }
 type TerraformRepositoryRepository struct {
 	Url        string `json:"url,omitempty"`

--- a/cmd/controllers/start.go
+++ b/cmd/controllers/start.go
@@ -38,6 +38,7 @@ func buildControllersStartCmd(app *burrito.App) *cobra.Command {
 	cmd.Flags().DurationVar(&app.Config.Controller.Timers.FailureGracePeriod, "failure-grace-period", defaultFailureGracePeriod, "initial time before retry, goes exponential function of number failure. Must end with s, m or h.")
 	cmd.Flags().IntVar(&app.Config.Controller.TerraformMaxRetries, "terraform-max-retries", 5, "default number of retries for terraform actions (can be overriden in CRDs)")
 	cmd.Flags().IntVar(&app.Config.Controller.MaxConcurrentReconciles, "max-concurrent-reconciles", 1, "maximum number of concurrent reconciles")
+	cmd.Flags().IntVar(&app.Config.Controller.MaxConcurrentRunnerPods, "max-runner-pods", 0, "maximum number of concurrent runner pods")
 	cmd.Flags().BoolVar(&app.Config.Controller.LeaderElection.Enabled, "leader-election", true, "whether leader election is enabled or not, default to true")
 	cmd.Flags().StringVar(&app.Config.Controller.LeaderElection.ID, "leader-election-id", "6d185457.terraform.padok.cloud", "lease id used for leader election")
 	cmd.Flags().StringVar(&app.Config.Controller.HealthProbeBindAddress, "health-probe-bind-address", ":8081", "address to bind the metrics server embedded in the controllers")

--- a/cmd/controllers/start.go
+++ b/cmd/controllers/start.go
@@ -38,7 +38,7 @@ func buildControllersStartCmd(app *burrito.App) *cobra.Command {
 	cmd.Flags().DurationVar(&app.Config.Controller.Timers.FailureGracePeriod, "failure-grace-period", defaultFailureGracePeriod, "initial time before retry, goes exponential function of number failure. Must end with s, m or h.")
 	cmd.Flags().IntVar(&app.Config.Controller.TerraformMaxRetries, "terraform-max-retries", 5, "default number of retries for terraform actions (can be overriden in CRDs)")
 	cmd.Flags().IntVar(&app.Config.Controller.MaxConcurrentReconciles, "max-concurrent-reconciles", 1, "maximum number of concurrent reconciles")
-	cmd.Flags().IntVar(&app.Config.Controller.MaxConcurrentRunnerPods, "max-runner-pods", 0, "maximum number of concurrent runner pods")
+	cmd.Flags().IntVar(&app.Config.Controller.MaxConcurrentRunnerPods, "max-concurrent-runner-pods", 0, "maximum number of concurrent runner pods")
 	cmd.Flags().BoolVar(&app.Config.Controller.LeaderElection.Enabled, "leader-election", true, "whether leader election is enabled or not, default to true")
 	cmd.Flags().StringVar(&app.Config.Controller.LeaderElection.ID, "leader-election-id", "6d185457.terraform.padok.cloud", "lease id used for leader election")
 	cmd.Flags().StringVar(&app.Config.Controller.HealthProbeBindAddress, "health-probe-bind-address", ":8081", "address to bind the metrics server embedded in the controllers")

--- a/deploy/charts/burrito/values.yaml
+++ b/deploy/charts/burrito/values.yaml
@@ -23,13 +23,15 @@ config:
         # -- Duration to wait before retrying on error
         onError: 10s
         # -- Duration to wait before retrying on locked layer
-        waitAction: 1m
+        waitAction: 10s
         # -- Duration to wait before retrying on failure (increases exponentially with the amount of failed retries)
         failureGracePeriod: 30
       # -- Default sync windows for layer reconciliation
       defaultSyncWindows: []
       # -- Maximum number of concurrent reconciles for the controller, increse this value if you have a lot of resources to reconcile
       maxConcurrentReconciles: 1
+      # -- Maximum number of concurrent runners pods. 0 means no limit
+      MaxConcurrentRunnerPods: 0
       # -- Maximum number of retries for Terraform operations (plan, apply...)
       terraformMaxRetries: 3
       # TODO: enable repository controller by default

--- a/docs/operator-manual/advanced-configuration.md
+++ b/docs/operator-manual/advanced-configuration.md
@@ -1,5 +1,8 @@
 # Advanced configuration
 
+Here are some important configuration options that can be set to customize Burrito's behavior.
+They can be set in the Helm chart [values](https://github.com/padok-team/burrito/blob/main/deploy/charts/burrito/values.yaml) or as environment variables.
+
 ## Controllers' configuration
 
 |              Environment variable              |                                 Description                                 |              Default               |
@@ -16,6 +19,8 @@
 |  `BURRITO_CONTROLLER_HEALTHPROBEBINDADDRESS`   |     address to bind the health probe server embedded in the controllers     |              `:8081`               |
 |    `BURRITO_CONTROLLER_METRICSBINDADDRESS`     |       address to bind the metrics server embedded in the controllers        |              `:8080`               |
 |   `BURRITO_CONTROLLER_KUBERNETESWEBHOOKPORT`   |   port used by the validating webhook server embedded in the controllers    |               `9443`               |
+|   `BURRITO_CONTROLLER_MAXCONCURRENTRECONCILES` |    number of parallel resource reconciliation performed by the contoller    |                `0`                 |
+|   `BURRITO_CONTROLLER_MAXCONCURRENTRUNNERPODS` | maximum number for pods that run in parallel to perform plan/apply (0=inf)  |                `0`                 |
 
 ## Server's configuration
 

--- a/docs/operator-manual/runner-scheduling.md
+++ b/docs/operator-manual/runner-scheduling.md
@@ -1,0 +1,15 @@
+# Fine-tuning the scheduling of runner pods
+
+Burrito creates runner pods to execute plans and apply changes on your infrastructure. The scheduling of these pods can be fine-tuned to better fit your needs. (e.g. to avoid running too many pods at the same time, or to reduce the cost of your underlying infrastructure).
+
+## Limit the number of runner pods in parallel
+
+By default, Burrito does not limit the number of runner pods that can run in parallel. This can lead to a high number of pods running at the same time, which can be costly or can overload your infrastructure.
+
+It is possible to limit the number of runner pods that can run in parallel by setting the `BURRITO_CONTROLLER_MAXCONCURRENTRUNNERPODS` environment variable in the controller, or by setting the `config.burrito.controller.maxConcurrentRunnerPods` value in the [Helm chart values file](https://github.com/padok-team/burrito/blob/main/deploy/charts/burrito/values.yaml).
+
+You can also set this value in the TerraformRepository CRD by setting the `spec.maxConcurrentRunnerPods` field.
+
+If the value of this parameter is set to `0`, there is no limit to the number of runner pods that can run in parallel.
+
+When Burrito creates a pod, if the setting is both set in the controller and in the TerraformRepository, the TerraformRepository value will take precedence.

--- a/internal/burrito/config/config.go
+++ b/internal/burrito/config/config.go
@@ -78,6 +78,7 @@ type ControllerConfig struct {
 	GitlabConfig            GitlabConfig                `mapstructure:"gitlabConfig"`
 	RunParallelism          int                         `mapstructure:"runParallelism"`
 	MaxConcurrentReconciles int                         `mapstructure:"maxConcurrentReconciles"`
+	MaxConcurrentRunnerPods int                         `mapstructure:"maxConcurrentRunnerPods"`
 }
 
 type GithubConfig struct {
@@ -231,6 +232,7 @@ func TestConfig() *Config {
 		Controller: ControllerConfig{
 			TerraformMaxRetries:     5,
 			MaxConcurrentReconciles: 1,
+			MaxConcurrentRunnerPods: 0,
 			Timers: ControllerTimers{
 				DriftDetection:     20 * time.Minute,
 				WaitAction:         5 * time.Minute,

--- a/internal/burrito/config/config_test.go
+++ b/internal/burrito/config/config_test.go
@@ -76,6 +76,7 @@ func TestConfig_FromYamlFile(t *testing.T) {
 			},
 			TerraformMaxRetries:     5,
 			MaxConcurrentReconciles: 1,
+			MaxConcurrentRunnerPods: 0,
 			Types:                   []string{"layer", "repository", "run", "pullrequest"},
 			LeaderElection: config.LeaderElectionConfig{
 				Enabled: true,
@@ -156,6 +157,7 @@ func TestConfig_EnvVarOverrides(t *testing.T) {
 	setEnvVar(t, "BURRITO_CONTROLLER_TIMERS_WAITACTION", "30s", &envVarList)
 	setEnvVar(t, "BURRITO_CONTROLLER_TIMERS_FAILUREGRACEPERIOD", "1m", &envVarList)
 	setEnvVar(t, "BURRITO_CONTROLLER_MAXCONCURRENTRECONCILES", "3", &envVarList)
+	setEnvVar(t, "BURRITO_CONTROLLER_MAXCONCURRENTRUNNERPODS", "10", &envVarList)
 	setEnvVar(t, "BURRITO_CONTROLLER_TERRAFORMMAXRETRIES", "32", &envVarList)
 	setEnvVar(t, "BURRITO_CONTROLLER_LEADERELECTION_ID", "other-leader-id", &envVarList)
 	setEnvVar(t, "BURRITO_CONTROLLER_GITHUBCONFIG_APPID", "123456", &envVarList)
@@ -224,6 +226,7 @@ func TestConfig_EnvVarOverrides(t *testing.T) {
 				},
 			},
 			MaxConcurrentReconciles: 3,
+			MaxConcurrentRunnerPods: 10,
 			TerraformMaxRetries:     32,
 			Types:                   []string{"layer", "repository"},
 			LeaderElection: config.LeaderElectionConfig{

--- a/internal/burrito/config/testdata/test-config-1.yaml
+++ b/internal/burrito/config/testdata/test-config-1.yaml
@@ -30,6 +30,7 @@ controller:
       actions: ["plan", "apply"]
   terraformMaxRetries: 5
   maxConcurrentReconciles: 1
+  maxConcurrentRunnerPods: 0
   types: ["layer", "repository", "run", "pullrequest"]
   leaderElection:
     enabled: true

--- a/internal/controllers/terraformrun/pod.go
+++ b/internal/controllers/terraformrun/pod.go
@@ -25,6 +25,7 @@ const (
 
 func getDefaultLabels(run *configv1alpha1.TerraformRun) map[string]string {
 	return map[string]string{
+		"burrito/component":  "runner",
 		"burrito/managed-by": run.Name,
 		"burrito/action":     string(run.Spec.Action),
 	}

--- a/internal/controllers/terraformrun/testdata/controller/parallel-case.yaml
+++ b/internal/controllers/terraformrun/testdata/controller/parallel-case.yaml
@@ -1,0 +1,32 @@
+apiVersion: config.terraform.padok.cloud/v1alpha1
+kind: TerraformRun
+metadata:
+  name: parallel-case-1
+  namespace: default
+spec:
+  action: plan
+  layer:
+    name: parallel-case-1
+    namespace: default
+---
+apiVersion: config.terraform.padok.cloud/v1alpha1
+kind: TerraformRun
+metadata:
+  name: parallel-case-2
+  namespace: default
+spec:
+  action: plan
+  layer:
+    name: parallel-case-2
+    namespace: default
+---
+apiVersion: config.terraform.padok.cloud/v1alpha1
+kind: TerraformRun
+metadata:
+  name: parallel-case-3
+  namespace: default
+spec:
+  action: plan
+  layer:
+    name: parallel-case-3
+    namespace: default

--- a/internal/controllers/terraformrun/testdata/controller/repository-layers.yaml
+++ b/internal/controllers/terraformrun/testdata/controller/repository-layers.yaml
@@ -77,3 +77,60 @@ spec:
   terragrunt:
     enabled: true
     version: 0.45.4
+---
+apiVersion: config.terraform.padok.cloud/v1alpha1
+kind: TerraformLayer
+metadata:
+  name: parallel-case-1
+  namespace: default
+spec:
+  branch: main
+  path: parallel-case-one/
+  remediationStrategy:
+    autoApply: true
+  repository:
+    name: burrito
+    namespace: default
+  terraform:
+    version: 1.3.1
+  terragrunt:
+    enabled: true
+    version: 0.45.4
+---
+apiVersion: config.terraform.padok.cloud/v1alpha1
+kind: TerraformLayer
+metadata:
+  name: parallel-case-2
+  namespace: default
+spec:
+  branch: main
+  path: parallel-case-two/
+  remediationStrategy:
+    autoApply: true
+  repository:
+    name: burrito
+    namespace: default
+  terraform:
+    version: 1.3.1
+  terragrunt:
+    enabled: true
+    version: 0.45.4
+---
+apiVersion: config.terraform.padok.cloud/v1alpha1
+kind: TerraformLayer
+metadata:
+  name: parallel-case-3
+  namespace: default
+spec:
+  branch: main
+  path: parallel-case-three/
+  remediationStrategy:
+    autoApply: true
+  repository:
+    name: burrito
+    namespace: default
+  terraform:
+    version: 1.3.1
+  terragrunt:
+    enabled: true
+    version: 0.45.4

--- a/manifests/crds/config.terraform.padok.cloud_terraformrepositories.yaml
+++ b/manifests/crds/config.terraform.padok.cloud_terraformrepositories.yaml
@@ -53,6 +53,8 @@ spec:
           spec:
             description: TerraformRepositorySpec defines the desired state of TerraformRepository
             properties:
+              maxConcurrentRuns:
+                type: integer
               opentofu:
                 properties:
                   enabled:

--- a/manifests/crds/config.terraform.padok.cloud_terraformrepositories.yaml
+++ b/manifests/crds/config.terraform.padok.cloud_terraformrepositories.yaml
@@ -53,7 +53,7 @@ spec:
           spec:
             description: TerraformRepositorySpec defines the desired state of TerraformRepository
             properties:
-              maxConcurrentRuns:
+              maxConcurrentRunnerPods:
                 type: integer
               opentofu:
                 properties:

--- a/manifests/install.yaml
+++ b/manifests/install.yaml
@@ -3515,6 +3515,8 @@ spec:
           spec:
             description: TerraformRepositorySpec defines the desired state of TerraformRepository
             properties:
+              maxConcurrentRuns:
+                type: integer
               opentofu:
                 properties:
                   enabled:

--- a/manifests/install.yaml
+++ b/manifests/install.yaml
@@ -3515,7 +3515,7 @@ spec:
           spec:
             description: TerraformRepositorySpec defines the desired state of TerraformRepository
             properties:
-              maxConcurrentRuns:
+              maxConcurrentRunnerPods:
                 type: integer
               opentofu:
                 properties:

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -34,6 +34,7 @@ nav:
   - operator-manual/multi-tenant-architecture.md
   - operator-manual/datastore.md
   - operator-manual/provider-caching.md
+  - operator-manual/runner-scheduling.md
 - User Guide:
   - user-guide/index.md
   - user-guide/override-runner.md


### PR DESCRIPTION
This PR adds a `MaxConcurrentRunnerPods` setting that can be set in the controller config and overriden in the TerraformRepository spec.
The setting defines the maximum number of concurrently running pods for burrito runners. No limit is defined if the setting is set to 0 (default).

The purpose of this is to limit the sudden burst in the amount workloads in the k8s cluster when a high amount of layers need to be planned or applied.