### PR TITLE
Update getting-started.md: missing burrito header

### DIFF
--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -21,9 +21,10 @@ For example, here is a default `values.yaml` file:
 
 ```yaml
 config:
-  datastore:
-    storage:
-      mock: true
+  burrito:
+    datastore:
+      storage:
+        mock: true
 
 tenants:
   - namespace:


### PR DESCRIPTION
The getting started docs are missing the `burrito` object that supersedes the component configs.

Following the natural flow of finding the repo and deploying for the first time, this causes the datastore config to not be set, and the pod logs are full of null pointer exceptions. 

ref: https://github.com/padok-team/burrito/blob/main/deploy/charts/burrito/values.yaml#L14