### PR TITLE
fix: [deploy] service type use service group value

### DIFF
--- a/deploy/charts/burrito/templates/datastore.yaml
+++ b/deploy/charts/burrito/templates/datastore.yaml
@@ -111,7 +111,7 @@ metadata:
   annotations:
     {{- toYaml .metadata.annotations | nindent 4}}
 spec:
-  type: {{ .type }}
+  type: {{ .service.type }}
   ports:
     {{- toYaml .service.ports | nindent 4 }}
   selector:

--- a/deploy/charts/burrito/templates/server.yaml
+++ b/deploy/charts/burrito/templates/server.yaml
@@ -123,7 +123,7 @@ metadata:
   annotations:
     {{- toYaml .metadata.annotations | nindent 4 }}
 spec:
-  type: {{ .type }}
+  type: {{ .service.type }}
   ports:
     {{- toYaml .service.ports | nindent 4 }}
   selector:


### PR DESCRIPTION
Currently the value for service type in the helm chart uses the top level `service` key in the global or component level values.

We should instead use the `service` group under both those respective sections to set the type of the services deployed.

(i use LoadBalancers for internal services, and would rather not expose via ingress)

this would break existing installs if they are seeing this value in its current location.