### PR TITLE
fix: [opentofu] no color

### DIFF
--- a/internal/runner/tools/opentofu/opentofu.go
+++ b/internal/runner/tools/opentofu/opentofu.go
@@ -21,7 +21,7 @@ func (t *OpenTofu) TenvName() string {
 
 func (t *OpenTofu) Init(workingDir string) error {
 	t.WorkingDir = workingDir
-	cmd := exec.Command(t.ExecPath, "init", "-upgrade")
+	cmd := exec.Command(t.ExecPath, "init", "-no-color", "-upgrade")
 	c.Verbose(cmd)
 	cmd.Dir = workingDir
 	if err := cmd.Run(); err != nil {
@@ -31,7 +31,7 @@ func (t *OpenTofu) Init(workingDir string) error {
 }
 
 func (t *OpenTofu) Plan(planArtifactPath string) error {
-	cmd := exec.Command(t.ExecPath, "plan", "-out", planArtifactPath)
+	cmd := exec.Command(t.ExecPath, "plan", "-no-color", "-out", planArtifactPath)
 	c.Verbose(cmd)
 	cmd.Dir = t.WorkingDir
 	if err := cmd.Run(); err != nil {
@@ -43,9 +43,9 @@ func (t *OpenTofu) Plan(planArtifactPath string) error {
 func (t *OpenTofu) Apply(planArtifactPath string) error {
 	var cmd *exec.Cmd
 	if planArtifactPath != "" {
-		cmd = exec.Command(t.ExecPath, "apply", "-auto-approve", planArtifactPath)
+		cmd = exec.Command(t.ExecPath, "apply", "-no-color", "-auto-approve", planArtifactPath)
 	} else {
-		cmd = exec.Command(t.ExecPath, "apply", "-auto-approve")
+		cmd = exec.Command(t.ExecPath, "apply", "-no-color", "-auto-approve")
 	}
 	c.Verbose(cmd)
 	cmd.Dir = t.WorkingDir
@@ -59,9 +59,9 @@ func (t *OpenTofu) Show(planArtifactPath, mode string) ([]byte, error) {
 	var cmd *exec.Cmd
 	switch mode {
 	case "json":
-		cmd = exec.Command(t.ExecPath, "show", "-json", planArtifactPath)
+		cmd = exec.Command(t.ExecPath, "show", "-no-color", "-json", planArtifactPath)
 	case "pretty":
-		cmd = exec.Command(t.ExecPath, "show", planArtifactPath)
+		cmd = exec.Command(t.ExecPath, "show", "-no-color", planArtifactPath)
 	default:
 		return nil, errors.New("invalid mode")
 	}


### PR DESCRIPTION
logs from opentofu runs are hard to read because of the symbols used to show colors in the terminal:

![image](https://github.com/user-attachments/assets/c06f9e74-9296-47df-8dd5-5488f2b60174)

you use the terraform-exec library for running terraform commands, which has `-no-color` set for all commands

- https://github.com/hashicorp/terraform-exec/blob/main/tfexec/init.go#L192
- https://github.com/hashicorp/terraform-exec/blob/main/tfexec/plan.go#L194
- https://github.com/hashicorp/terraform-exec/blob/main/tfexec/show.go#L215
- https://github.com/hashicorp/terraform-exec/blob/main/tfexec/apply.go#L176

so i have added this flag to all opentofu commands, and the output is readable now:

![image](https://github.com/user-attachments/assets/fba3a057-4c91-4e0f-856f-58eae5111a2f)

tested by running my own version of the controller image: https://hub.docker.com/layers/rssnyder/burrito/dev/images/sha256-86c98df34408aa00c906950531dbb60f0578fcf7d091e006aeeea6cdc5ddde16