### PR TITLE
fix: return rc=2 for unsupported commands

### DIFF
--- a/cmd/controllers/controller.go
+++ b/cmd/controllers/controller.go
@@ -15,7 +15,7 @@ func BuildControllersCmd(app *burrito.App) *cobra.Command {
 		Short: "cmd to use burrito's controllers",
 		RunE: func(cmd *cobra.Command, args []string) error {
 			// If we reach this point, it means no subcommand was matched
-			cmdUtils.UnsupportedCommand("controllers", args)
+			cmdUtils.UnsupportedCommand(cmd, args)
 			return cmd.Help()
 		},
 	}

--- a/cmd/controllers/controller.go
+++ b/cmd/controllers/controller.go
@@ -5,7 +5,7 @@ package controllers
 
 import (
 	"github.com/padok-team/burrito/internal/burrito"
-
+	cmdUtils "github.com/padok-team/burrito/internal/utils/cmd"
 	"github.com/spf13/cobra"
 )
 
@@ -13,6 +13,11 @@ func BuildControllersCmd(app *burrito.App) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "controllers",
 		Short: "cmd to use burrito's controllers",
+		RunE: func(cmd *cobra.Command, args []string) error {
+			// If we reach this point, it means no subcommand was matched
+			cmdUtils.UnsupportedCommand("controllers", args)
+			return cmd.Help()
+		},
 	}
 	cmd.AddCommand(buildControllersStartCmd(app))
 	return cmd

--- a/cmd/datastore/datastore.go
+++ b/cmd/datastore/datastore.go
@@ -5,6 +5,7 @@ package datastore
 
 import (
 	"github.com/padok-team/burrito/internal/burrito"
+	cmdUtils "github.com/padok-team/burrito/internal/utils/cmd"
 	"github.com/spf13/cobra"
 )
 
@@ -12,6 +13,11 @@ func BuildDatastoreCmd(app *burrito.App) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "datastore",
 		Short: "cmd to use burrito's datastore",
+		RunE: func(cmd *cobra.Command, args []string) error {
+			// If we reach this point, it means no subcommand was matched
+			cmdUtils.UnsupportedCommand("datastore", args)
+			return cmd.Help()
+		},
 	}
 	cmd.AddCommand(buildDatastoreStartCmd(app))
 	return cmd

--- a/cmd/datastore/datastore.go
+++ b/cmd/datastore/datastore.go
@@ -15,7 +15,7 @@ func BuildDatastoreCmd(app *burrito.App) *cobra.Command {
 		Short: "cmd to use burrito's datastore",
 		RunE: func(cmd *cobra.Command, args []string) error {
 			// If we reach this point, it means no subcommand was matched
-			cmdUtils.UnsupportedCommand("datastore", args)
+			cmdUtils.UnsupportedCommand(cmd, args)
 			return cmd.Help()
 		},
 	}

--- a/cmd/runner/runner.go
+++ b/cmd/runner/runner.go
@@ -5,6 +5,7 @@ package runner
 
 import (
 	"github.com/padok-team/burrito/internal/burrito"
+	cmdUtils "github.com/padok-team/burrito/internal/utils/cmd"
 	"github.com/spf13/cobra"
 )
 
@@ -12,6 +13,11 @@ func BuildRunnerCmd(app *burrito.App) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "runner",
 		Short: "cmd to use burrito's runner",
+		RunE: func(cmd *cobra.Command, args []string) error {
+			// If we reach this point, it means no subcommand was matched
+			cmdUtils.UnsupportedCommand("runner", args)
+			return cmd.Help()
+		},
 	}
 	cmd.AddCommand(buildRunnerStartCmd(app))
 	return cmd

--- a/cmd/runner/runner.go
+++ b/cmd/runner/runner.go
@@ -15,7 +15,7 @@ func BuildRunnerCmd(app *burrito.App) *cobra.Command {
 		Short: "cmd to use burrito's runner",
 		RunE: func(cmd *cobra.Command, args []string) error {
 			// If we reach this point, it means no subcommand was matched
-			cmdUtils.UnsupportedCommand("runner", args)
+			cmdUtils.UnsupportedCommand(cmd, args)
 			return cmd.Help()
 		},
 	}

--- a/cmd/server/server.go
+++ b/cmd/server/server.go
@@ -12,7 +12,7 @@ func BuildServerCmd(app *burrito.App) *cobra.Command {
 		Short: "cmd to use burrito's server",
 		RunE: func(cmd *cobra.Command, args []string) error {
 			// If we reach this point, it means no subcommand was matched
-			cmdUtils.UnsupportedCommand("server", args)
+			cmdUtils.UnsupportedCommand(cmd, args)
 			return cmd.Help()
 		},
 	}

--- a/cmd/server/server.go
+++ b/cmd/server/server.go
@@ -2,6 +2,7 @@ package server
 
 import (
 	"github.com/padok-team/burrito/internal/burrito"
+	cmdUtils "github.com/padok-team/burrito/internal/utils/cmd"
 	"github.com/spf13/cobra"
 )
 
@@ -9,6 +10,11 @@ func BuildServerCmd(app *burrito.App) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "server",
 		Short: "cmd to use burrito's server",
+		RunE: func(cmd *cobra.Command, args []string) error {
+			// If we reach this point, it means no subcommand was matched
+			cmdUtils.UnsupportedCommand("server", args)
+			return cmd.Help()
+		},
 	}
 	cmd.AddCommand(buildServerStartCmd(app))
 	return cmd

--- a/internal/utils/cmd/cmd.go
+++ b/internal/utils/cmd/cmd.go
@@ -1,6 +1,7 @@
 package cmd
 
 import (
+	"fmt"
 	"os"
 	"os/exec"
 )
@@ -8,4 +9,12 @@ import (
 func Verbose(cmd *exec.Cmd) {
 	cmd.Stdout = os.Stdout
 	cmd.Stderr = os.Stderr
+}
+
+func UnsupportedCommand(subcommand string, args []string) {
+	if len(args) > 0 {
+		fmt.Fprintf(os.Stderr, "Error: unknown %s subcommand: %s\n", subcommand, args[0])
+	}
+	fmt.Fprintf(os.Stderr, "Run 'burrito %s --help' for usage", subcommand)
+	os.Exit(2)
 }

--- a/internal/utils/cmd/cmd.go
+++ b/internal/utils/cmd/cmd.go
@@ -18,6 +18,9 @@ func UnsupportedCommand(cmd *cobra.Command, args []string) {
 		fmt.Fprintf(os.Stderr, "Error: unknown %s subcommand: %s\n", cmd.Use, args[0])
 	}
 	fmt.Fprintf(os.Stderr, "Run 'burrito %s --help' for usage\n", cmd.Use)
-	cmd.Help()
+	if err := cmd.Help(); err != nil {
+		fmt.Fprintf(os.Stderr, "Error displaying help: %v\n", err)
+		os.Exit(1)
+	}
 	os.Exit(2)
 }

--- a/internal/utils/cmd/cmd.go
+++ b/internal/utils/cmd/cmd.go
@@ -4,6 +4,8 @@ import (
 	"fmt"
 	"os"
 	"os/exec"
+
+	"github.com/spf13/cobra"
 )
 
 func Verbose(cmd *exec.Cmd) {
@@ -11,10 +13,11 @@ func Verbose(cmd *exec.Cmd) {
 	cmd.Stderr = os.Stderr
 }
 
-func UnsupportedCommand(subcommand string, args []string) {
+func UnsupportedCommand(cmd *cobra.Command, args []string) {
 	if len(args) > 0 {
-		fmt.Fprintf(os.Stderr, "Error: unknown %s subcommand: %s\n", subcommand, args[0])
+		fmt.Fprintf(os.Stderr, "Error: unknown %s subcommand: %s\n", cmd.Use, args[0])
 	}
-	fmt.Fprintf(os.Stderr, "Run 'burrito %s --help' for usage", subcommand)
+	fmt.Fprintf(os.Stderr, "Run 'burrito %s --help' for usage\n", cmd.Use)
+	cmd.Help()
 	os.Exit(2)
 }


### PR DESCRIPTION
This PR returns rc=2 for unsupported commands. 
Before, if you override the `args` for a component with a mistake, it happily returned 0. This can be misleading once in k8s, especially on the runner part which shown a `Completed` status whereas it totally crashed.

Now this returns a different rc and an error:

```bash
╰ go build -o bin/burrito main.go && bin/burrito server unsupportedcommand ; echo $?
Error: unknown server subcommand: unsupportedcommand
Run 'burrito server --help' for usagecmd to use burrito's server

Usage:
  burrito server [flags]
  burrito server [command]

Available Commands:
  start       Start burrito's server

Flags:
  -h, --help   help for server

Use "burrito server [command] --help" for more information about a command.
2
```