### PR TITLE
fix(s3): remove ChecksumAlgorithm

### DIFF
--- a/internal/datastore/storage/s3/s3.go
+++ b/internal/datastore/storage/s3/s3.go
@@ -18,9 +18,8 @@ import (
 
 // Implements Storage interface using AWS S3
 type S3 struct {
-	Client                 *storage.Client
-	Config                 config.S3Config
-	supportsChecksumSha256 bool
+	Client *storage.Client
+	Config config.S3Config
 }
 
 // New creates a new AWS S3 client
@@ -32,16 +31,10 @@ func New(config config.S3Config) *S3 {
 	client := storage.NewFromConfig(sdkConfig, func(o *storage.Options) {
 		o.UsePathStyle = config.UsePathStyle
 	})
-	s3Client := &S3{
-		Config:                 config,
-		Client:                 client,
-		supportsChecksumSha256: false,
+	return &S3{
+		Config: config,
+		Client: client,
 	}
-
-	// Check for checksum support during initialization
-	s3Client.IsChecksumSha256Supported()
-
-	return s3Client
 }
 
 func (a *S3) Get(key string) ([]byte, error) {
@@ -109,11 +102,6 @@ func (a *S3) Set(key string, data []byte, ttl int) error {
 		Key:    &key,
 		Body:   bytes.NewReader(data),
 	}
-
-	if a.supportsChecksumSha256 {
-		input.ChecksumAlgorithm = types.ChecksumAlgorithmSha256
-	}
-
 	_, err := a.Client.PutObject(context.TODO(), input)
 	if err != nil {
 		return err
@@ -161,33 +149,4 @@ func (a *S3) List(prefix string) ([]string, error) {
 	}
 
 	return keys, nil
-}
-
-func (a *S3) IsChecksumSha256Supported() bool {
-	// Create a test input with SHA256 checksum algorithm
-	testInput := &storage.PutObjectInput{
-		Bucket:            &a.Config.Bucket,
-		Key:               aws.String("_test_checksum_support"),
-		Body:              bytes.NewReader([]byte("test")),
-		ChecksumAlgorithm: types.ChecksumAlgorithmSha256,
-	}
-
-	// Try to put an object with checksum algorithm
-	_, err := a.Client.PutObject(context.TODO(), testInput)
-
-	// Clean up the test object regardless of the result
-	// Ignore any error from deletion as it's just a cleanup operation
-	deleteInput := &storage.DeleteObjectInput{
-		Bucket: &a.Config.Bucket,
-		Key:    aws.String("_test_checksum_support"),
-	}
-	a.Client.DeleteObject(context.TODO(), deleteInput)
-
-	if err != nil {
-		a.supportsChecksumSha256 = false
-		return false
-	}
-
-	a.supportsChecksumSha256 = true
-	return true
 }


### PR DESCRIPTION
Fixes #602 by checking `ChecksumAlgorithmSha256` support on the s3 bucket
The check is made only on datastore startup