### PR TITLE
fix: get the right plan if there were several attempts

### DIFF
--- a/internal/controllers/terraformlayer/controller.go
+++ b/internal/controllers/terraformlayer/controller.go
@@ -19,6 +19,7 @@ package terraformlayer
 import (
 	"context"
 	e "errors"
+	"strconv"
 	"time"
 
 	"github.com/google/go-cmp/cmp"
@@ -119,7 +120,19 @@ func (r *Reconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Resu
 	state, conditions := r.GetState(ctx, layer)
 	lastResult := []byte("Layer has never been planned")
 	if layer.Status.LastRun.Name != "" {
-		lastResult, err = r.Datastore.GetPlan(layer.Namespace, layer.Name, layer.Status.LastRun.Name, "", "short")
+		// Get attempt from TerraformRun if available
+		attempt := ""
+		run := &configv1alpha1.TerraformRun{}
+		err := r.Client.Get(ctx, types.NamespacedName{
+			Namespace: layer.Namespace,
+			Name:      layer.Status.LastRun.Name,
+		}, run)
+
+		if err == nil && run.Status.Retries > 0 {
+			attempt = strconv.Itoa(run.Status.Retries)
+		}
+
+		lastResult, err = r.Datastore.GetPlan(layer.Namespace, layer.Name, layer.Status.LastRun.Name, attempt, "short")
 		if err != nil {
 			log.Errorf("failed to get plan for layer %s: %s", layer.Name, err)
 			r.Recorder.Event(layer, corev1.EventTypeNormal, "Reconciliation", "Failed to get last Result")


### PR DESCRIPTION
This PR fixes #606 

I created 1000 `random_pet` layers, added them all at once to stress the system and observed the behavior. 

To force retries, I randomly crashed running pods on-purpose:
```
╰ while [ true ] ; do sleep 3; kubectl get pods | awk '/test-layer.*Running/{print $1}' | parallel -j20 'kubectl delete pod {}'; done
pod "test-layer-937-plan-bqcpl" deleted
pod "test-layer-502-plan-88vtd" deleted
pod "test-layer-502-plan-429nd" deleted
[...]
```
So I got my retries as expected
```
╰ kubectl get terraformrun
NAME                        STATE       RETRIES   CREATED ON             RUNNER POD
test-layer-787-plan-rs42h   Succeeded   4         2025-05-25T08:05:34Z   test-layer-787-plan-9ggmd
test-layer-788-plan-zv6c8   Succeeded   0         2025-05-25T08:06:14Z   test-layer-788-plan-cp876
test-layer-840-plan-8zcph   Succeeded   1         2025-05-25T08:06:24Z   test-layer-840-plan-ctf7v
test-layer-880-plan-s4q89   Succeeded   0         2025-05-25T08:04:44Z   test-layer-880-plan-b8k77
test-layer-889-plan-c6fmt   Succeeded   0         2025-05-25T08:06:24Z   test-layer-889-plan-tfplx
test-layer-937-plan-bq9st   Succeeded   2         2025-05-25T08:06:44Z   test-layer-937-plan-m5rf2
test-layer-951-plan-hlqrk   Succeeded   0         2025-05-25T08:08:35Z   test-layer-951-plan-rs42h
```
I checked datastore logs and saw that now, reconciliation autocorrects the `attempt`, thus the `status` changes from 404 to 200 :smile: 
```
time="2025-05-25T08:07:04Z" level=info bytes_in= bytes_out=24 error="<nil>" latency="29.305µs" method=GET remote_ip=10.244.0.225 service_account="system:serviceaccount:burrito-system:burrito-controllers" status=404 uri="/api/plans?attempt=1&format=short&layer=test-layer-937&namespace=burrito-project&run=test-layer-937-plan-bq9st"
time="2025-05-25T08:07:08Z" level=info bytes_in=798 bytes_out=0 error="<nil>" latency="980.393µs" method=PUT remote_ip=10.244.0.14 service_account="system:serviceaccount:burrito-project:burrito-runner" status=200 uri="/api/plans?attempt=2&format=pretty&layer=test-layer-937&namespace=burrito-project&run=test-layer-937-plan-bq9st"
```