### PR TITLE
ci: build should run when lint and tests are ok

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -81,4 +81,5 @@ jobs:
           args: --timeout=5m
 
   build-and-push:
+    needs: [unit-tests, check-codegen, lint-go]
     uses: ./.github/workflows/build-and-push.yaml


### PR DESCRIPTION
This PR triggers the build only on a successful result of the `Continuous Integration` workflow
This has been seen at https://github.com/padok-team/burrito/actions/runs/15412299398 