### PR TITLE
fix(layer-controller): consider layer not running when runs are not found

### DIFF
--- a/internal/controllers/terraformlayer/conditions.go
+++ b/internal/controllers/terraformlayer/conditions.go
@@ -35,9 +35,9 @@ func (r *Reconciler) IsRunning(t *configv1alpha1.TerraformLayer) (metav1.Conditi
 	}, &run)
 	if errors.IsNotFound(err) {
 		condition.Reason = "RunNotFound"
-		condition.Message = "The Last Run does not exist, this is likely a bug, considering layer is running"
-		condition.Status = metav1.ConditionTrue
-		return condition, true
+		condition.Message = "The Last Run could not be fetched, it might have been manually deleted, considering layer is not running"
+		condition.Status = metav1.ConditionFalse
+		return condition, false
 	}
 	if err != nil {
 		condition.Reason = "RunRetrievalError"

--- a/internal/controllers/terraformlayer/testdata/unknown-cases.yaml
+++ b/internal/controllers/terraformlayer/testdata/unknown-cases.yaml
@@ -18,3 +18,25 @@ spec:
   terragrunt:
     enabled: true
     version: 0.45.4
+
+---
+apiVersion: config.terraform.padok.cloud/v1alpha1
+kind: TerraformLayer
+metadata:
+  name: last-run-not-exist
+  namespace: default
+spec:
+  branch: main
+  path: last-run-not-exist/
+  remediationStrategy:
+    autoApply: true
+  repository:
+    name: burrito
+    namespace: default
+  terraform:
+    enabled: true
+    version: 1.3.1
+status:
+  lastRun:
+    name: run-does-not-exist
+    namespace: default


### PR DESCRIPTION
Fixes #591 
Since there are owner references between runs and associated pods, it makes sense to consider the status of the layer as not running when runs associated to the last action are not found by the controller.