### PR TITLE
feat: add support for datastore encryption

### DIFF
--- a/docs/operator-manual/datastore.md
+++ b/docs/operator-manual/datastore.md
@@ -9,6 +9,8 @@ config:
   burrito:
     datastore:
       storage:
+        encryption:
+          enabled: <false|true> # default: false
         mock: <false|true> # default: false
         s3:
           bucket: <bucket-name>
@@ -25,6 +27,81 @@ config:
 
 !!! warning
     The `mock` storage backend is only for testing purposes and should not be used in production. If enabled, Burrito will store the data in memory and will lose it when the pod is restarted. It also might fill up the memory of the pod if too much data is stored.
+
+## Encryption
+
+### Configuration
+
+Burrito supports encryption of data at rest in the datastore. When encryption is enabled, all data stored in the backend storage will be encrypted using AES-256-CBC. This allows you to decrypt with external tools such as `openssl`
+
+To enable encryption, you need to:
+
+1. Set `encryption.enabled: true` in the configuration
+2. Provide an encryption key via the `BURRITO_DATASTORE_STORAGE_ENCRYPTION_KEY` environment variable, through a Kubernetes secret like below
+
+```yaml
+config:
+  burrito:
+    datastore:
+      storage:
+        encryption:
+          enabled: true
+
+datastore:
+  deployment:
+    envFrom:
+      - secretRef:
+          name: burrito-datastore-encryption-key
+```
+
+You'll need to create a secret containing the encryption key:
+
+```yaml
+apiVersion: v1
+kind: Secret
+metadata:
+  name: burrito-datastore-encryption-key
+  namespace: <datastoreNamespace>
+type: Opaque
+stringData:
+  BURRITO_DATASTORE_STORAGE_ENCRYPTION_KEY: <your-base64-encoded-encryption-key>
+```
+
+!!! warning
+    Losing the encryption key will make all encrypted data unrecoverable. Make sure to back up your encryption key securely.
+
+### Security Notes
+
+- Always keep your encryption keys secure
+- The IV is stored in plaintext at the beginning of each encrypted file (this is standard practice)
+- Each encryption operation uses a random IV, ensuring the same plaintext produces different ciphertext
+
+### Files format
+
+The encrypted files use the following format:
+- First 16 bytes: Initialization Vector (IV)
+- Remaining bytes: AES-256-CBC encrypted data with PKCS#7 padding
+
+The encryption key is derived by taking the SHA-256 hash of the provided key string.
+
+### Decrypting with OpenSSL
+
+You have downloaded the encrypted file, you can now start to decrypt it:
+
+```bash
+# Extract the first 16 bytes (IV) as hex
+IV_HEX=$(xxd -l 16 -p plan.json)
+
+# derivate your key with sha256
+KEY_HASH=$(echo -n "your-encryption-key" | sha256sum | cut -d' ' -f1)
+
+# decrypt the file
+openssl enc -aes-256-cbc -d -in plan.json -K "${KEY_HASH}" -iv "${IV_HEX}"
+```
+
+### Encrypting existing files
+
+If you enable encryption on an existing datastore with unencrypted files, you can use the `/encrypt` endpoint to encrypt all existing files. See the [Encrypt Endpoint documentation](encrypt-endpoint.md) for detailed usage instructions.
 
 ## Authentication
 

--- a/docs/operator-manual/encrypt-endpoint.md
+++ b/docs/operator-manual/encrypt-endpoint.md
@@ -1,0 +1,118 @@
+# Encrypt Endpoint
+
+The `/encrypt` endpoint allows you to encrypt all files in the datastore. This is useful when you need to migrate from unencrypted to encrypted storage.
+
+## Endpoint
+
+`POST /api/encrypt`
+
+## Request Body
+
+```json
+{
+  "encryptionKey": "your-encryption-key"
+}
+```
+
+## Parameters
+
+- `encryptionKey` (required): The encryption key that must match the server's configured encryption key
+
+## Authentication
+
+The endpoint requires the same authentication as other datastore endpoints (service account token).
+
+## Response
+
+### Success Response (200 OK)
+
+```json
+{
+  "message": "Encryption process completed. X files encrypted.",
+  "filesEncrypted": 42,
+  "errors": []
+}
+```
+
+### Partial Success Response (206 Partial Content)
+
+```json
+{
+  "message": "Encryption process completed. X files encrypted.",
+  "filesEncrypted": 38,
+  "errors": [
+    "Failed to encrypt layers/namespace/layer/run/attempt/file.json: error details",
+    "Failed to encrypt repositories/namespace/repo/branch/commit.gitbundle: error details"
+  ]
+}
+```
+
+### Error Responses
+
+#### 400 Bad Request
+- Missing encryption key in request body
+- Encryption is not enabled in configuration
+
+#### 401 Unauthorized  
+- Invalid encryption key (doesn't match server configuration)
+
+#### 500 Internal Server Error
+- No encryption key configured on server
+
+## Usage Example
+
+### Authorization Configuration
+
+By default, burrito comes with these authorized service accounts:
+- `burrito-project/burrito-runner`
+- `burrito-system/burrito-controllers`  
+- `burrito-system/burrito-server`
+
+To add additional service accounts, update your Helm values:
+
+```yaml
+config:
+  burrito:
+    datastore:
+      serviceAccounts:
+        - burrito-project/burrito-runner
+        - burrito-system/burrito-controllers
+        - burrito-system/burrito-server
+        - burrito-system/your-custom-service-account # Add custom accounts here
+```
+
+### Usage Examples
+
+Once you have the token, use it in your API calls:
+
+```bash
+# enable port-forward to your datastore
+kubectl port-forward $(kubectl get pods -n burrito-system | awk '/burrito-datastore/{print $1}') -n burrito-system 8080:8080
+
+# Get a token using the burrito-server service account (recommended)
+TOKEN=$(kubectl create token burrito-server -n burrito-system --audience=burrito)
+
+# Use it with curl
+curl -X POST http://localhost:8080/api/encrypt \
+  -H "Content-Type: application/json" \
+  -H "Authorization: $TOKEN" \
+  -d '{"encryptionKey": "your-encryption-key"}'
+```
+
+## Prerequisites
+
+1. Encryption must be enabled in the datastore configuration
+2. The `BURRITO_DATASTORE_STORAGE_ENCRYPTION_KEY` environment variable must be set
+3. The provided encryption key must match the configured server key
+4. A service account with proper authorization must be configured (see "Getting the Authorization Bearer Token" section)
+5. The service account must be listed in the datastore's `serviceAccounts` configuration
+
+## Behavior
+
+- The endpoint will list all files in `layers/` prefix
+- For each file, it tests if the file is already encrypted by attempting to decrypt it
+- **Files that are already encrypted will be skipped** - no double encryption occurs
+- Only unencrypted files will be encrypted and stored back
+- The process continues even if some files fail to encrypt
+- Progress is logged every 100 files processed
+- The response includes the count of files that were actually encrypted (skipped files are not counted)

--- a/internal/burrito/config/config.go
+++ b/internal/burrito/config/config.go
@@ -30,10 +30,11 @@ type DatastoreConfig struct {
 }
 
 type StorageConfig struct {
-	GCS   GCSConfig   `mapstructure:"gcs"`
-	S3    S3Config    `mapstructure:"s3"`
-	Azure AzureConfig `mapstructure:"azure"`
-	Mock  bool        `mapstructure:"mock"`
+	GCS        GCSConfig        `mapstructure:"gcs"`
+	S3         S3Config         `mapstructure:"s3"`
+	Azure      AzureConfig      `mapstructure:"azure"`
+	Mock       bool             `mapstructure:"mock"`
+	Encryption EncryptionConfig `mapstructure:"encryption"`
 }
 
 type GCSConfig struct {
@@ -48,6 +49,10 @@ type S3Config struct {
 type AzureConfig struct {
 	StorageAccount string `mapstructure:"storageAccount"`
 	Container      string `mapstructure:"container"`
+}
+
+type EncryptionConfig struct {
+	Enabled bool `mapstructure:"enabled"`
 }
 
 type WebhookConfig struct {

--- a/internal/datastore/api/encrypt.go
+++ b/internal/datastore/api/encrypt.go
@@ -1,0 +1,169 @@
+package api
+
+import (
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"os"
+	"strings"
+
+	"github.com/labstack/echo/v4"
+	log "github.com/sirupsen/logrus"
+)
+
+type EncryptRequest struct {
+	EncryptionKey string `json:"encryptionKey"`
+}
+
+type EncryptResponse struct {
+	Message        string   `json:"message"`
+	FilesEncrypted int      `json:"filesEncrypted"`
+	Errors         []string `json:"errors,omitempty"`
+}
+
+func (a *API) EncryptAllFilesHandler(c echo.Context) error {
+	// Parse the request body
+	body, err := io.ReadAll(c.Request().Body)
+	if err != nil {
+		return c.JSON(http.StatusBadRequest, map[string]string{
+			"error": "Failed to read request body",
+		})
+	}
+
+	var req EncryptRequest
+	if err := json.Unmarshal(body, &req); err != nil {
+		return c.JSON(http.StatusBadRequest, map[string]string{
+			"error": "Invalid JSON format",
+		})
+	}
+
+	if req.EncryptionKey == "" {
+		return c.JSON(http.StatusBadRequest, map[string]string{
+			"error": "encryptionKey is required",
+		})
+	}
+
+	// Get the configured encryption key from environment variable
+	configuredKey := os.Getenv("BURRITO_DATASTORE_STORAGE_ENCRYPTION_KEY")
+	if configuredKey == "" {
+		return c.JSON(http.StatusInternalServerError, map[string]string{
+			"error": "No encryption key configured on server",
+		})
+	}
+
+	// Compare the provided key with the configured key
+	if req.EncryptionKey != configuredKey {
+		return c.JSON(http.StatusUnauthorized, map[string]string{
+			"error": "Invalid encryption key",
+		})
+	}
+
+	// Check if encryption is enabled in configuration
+	if !a.config.Datastore.Storage.Encryption.Enabled {
+		return c.JSON(http.StatusBadRequest, map[string]string{
+			"error": "Encryption is not enabled in configuration",
+		})
+	}
+
+	log.Info("Starting encryption of all files in datastore")
+
+	// Encrypt all files
+	filesEncrypted, errors := a.encryptAllFiles()
+
+	response := EncryptResponse{
+		Message:        fmt.Sprintf("Encryption process completed. %d files encrypted.", filesEncrypted),
+		FilesEncrypted: filesEncrypted,
+		Errors:         errors,
+	}
+
+	if len(errors) > 0 {
+		log.Warnf("Encryption completed with %d errors", len(errors))
+		return c.JSON(http.StatusPartialContent, response)
+	}
+
+	log.Infof("Successfully encrypted %d files", filesEncrypted)
+	return c.JSON(http.StatusOK, response)
+}
+
+func (a *API) encryptAllFiles() (int, []string) {
+	var filesEncrypted int
+	var errors []string
+
+	// List all files in both layers and repositories prefixes
+	prefixes := []string{"layers"}
+
+	for _, prefix := range prefixes {
+		files, err := a.Storage.Backend.ListRecursive(prefix)
+		if err != nil {
+			errors = append(errors, fmt.Sprintf("Failed to list files in %s: %v", prefix, err))
+			continue
+		}
+
+		for _, file := range files {
+			// Skip if this looks like a directory (ends with /)
+			if strings.HasSuffix(file, "/") {
+				continue
+			}
+
+			err := a.encryptSingleFile(file)
+			if err != nil {
+				errors = append(errors, fmt.Sprintf("Failed to encrypt %s: %v", file, err))
+				continue
+			}
+
+			filesEncrypted++
+			if filesEncrypted%100 == 0 {
+				log.Infof("Encrypted %d files so far...", filesEncrypted)
+			}
+		}
+	}
+
+	return filesEncrypted, errors
+}
+
+func (a *API) encryptSingleFile(filePath string) error {
+	// Get the current file content
+	data, err := a.Storage.Backend.Get(filePath)
+	if err != nil {
+		return fmt.Errorf("failed to get file: %w", err)
+	}
+
+	// Extract namespace from file path for encryption
+	// File paths are typically: layers/namespace/layer/run/attempt/file or repositories/namespace/repo/branch/revision.gitbundle
+	pathParts := strings.Split(strings.TrimPrefix(filePath, "/"), "/")
+	if len(pathParts) < 2 {
+		return fmt.Errorf("invalid file path format: %s", filePath)
+	}
+
+	namespace := pathParts[1] // Second part is always the namespace
+
+	// Check if the file is already encrypted by trying to decrypt it directly with the encryptor
+	encryptor := a.Storage.EncryptionManager.GetEncryptor(namespace)
+	if encryptor == nil {
+		return fmt.Errorf("no encryptor available for namespace %s", namespace)
+	}
+
+	// Try to decrypt the raw data directly. If it succeeds, the file is encrypted
+	_, err = encryptor.Decrypt(data)
+	if err == nil {
+		// Decryption succeeded, so the file is already encrypted
+		log.Infof("Skipping already encrypted file: %s", filePath)
+		return nil
+	}
+
+	// Decryption failed, so the file is likely not encrypted. Encrypt it.
+	encrypted, err := encryptor.Encrypt(data)
+	if err != nil {
+		return fmt.Errorf("failed to encrypt: %w", err)
+	}
+
+	// Store the encrypted data back
+	err = a.Storage.Backend.Set(filePath, encrypted, 0)
+	if err != nil {
+		return fmt.Errorf("failed to store encrypted file: %w", err)
+	}
+
+	log.Infof("Successfully encrypted file: %s", filePath)
+	return nil
+}

--- a/internal/datastore/api/encrypt_test.go
+++ b/internal/datastore/api/encrypt_test.go
@@ -1,0 +1,238 @@
+package api_test
+
+import (
+	"bytes"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"os"
+
+	"github.com/labstack/echo/v4"
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	"github.com/padok-team/burrito/internal/burrito/config"
+	"github.com/padok-team/burrito/internal/datastore/api"
+	"github.com/padok-team/burrito/internal/datastore/storage"
+)
+
+var _ = Describe("Encrypt API", func() {
+	var (
+		testAPI *api.API
+		e       *echo.Echo
+	)
+
+	BeforeEach(func() {
+		// Set up test environment with encryption enabled
+		os.Setenv("BURRITO_DATASTORE_STORAGE_ENCRYPTION_KEY", "test-encryption-key")
+
+		config := config.Config{
+			Datastore: config.DatastoreConfig{
+				Storage: config.StorageConfig{
+					Mock: true,
+					Encryption: config.EncryptionConfig{
+						Enabled: true,
+					},
+				},
+			},
+		}
+
+		testAPI = &api.API{}
+		testAPI.Storage = storage.New(config)
+		testAPI = &api.API{}
+		testAPI.Storage = storage.New(config)
+		testAPI = &api.API{}
+		testAPI.Storage = storage.New(config)
+		testAPI = api.New(&config)
+		testAPI.Storage = storage.New(config)
+		e = echo.New()
+	})
+
+	AfterEach(func() {
+		os.Unsetenv("BURRITO_DATASTORE_STORAGE_ENCRYPTION_KEY")
+	})
+
+	Describe("POST /encrypt", func() {
+		Context("when encryption is enabled and key is valid", func() {
+			It("should encrypt all files successfully", func() {
+				// Pre-populate some test data
+				testAPI.Storage.PutLogs("test-namespace", "test-layer", "test-run", "0", []byte("test logs"))
+				testAPI.Storage.PutPlan("test-namespace", "test-layer", "test-run", "0", "json", []byte("test plan"))
+
+				// Prepare request
+				reqBody := map[string]string{
+					"encryptionKey": "test-encryption-key",
+				}
+				jsonBody, _ := json.Marshal(reqBody)
+
+				req := httptest.NewRequest(http.MethodPost, "/encrypt", bytes.NewBuffer(jsonBody))
+				req.Header.Set("Content-Type", "application/json")
+				rec := httptest.NewRecorder()
+				c := e.NewContext(req, rec)
+
+				// Execute request
+				err := testAPI.EncryptAllFilesHandler(c)
+				Expect(err).NotTo(HaveOccurred())
+				// Accept both OK and Partial Content (when there are some errors but process completes)
+				Expect(rec.Code).To(Or(Equal(http.StatusOK), Equal(http.StatusPartialContent)))
+
+				// Check response
+				var response map[string]interface{}
+				err = json.Unmarshal(rec.Body.Bytes(), &response)
+				Expect(err).NotTo(HaveOccurred())
+				Expect(response["message"]).To(ContainSubstring("Encryption process completed"))
+				// For debugging, let's see what the actual response is
+				GinkgoWriter.Printf("Response: %+v\n", response)
+			})
+		})
+
+		Context("when encryption key is invalid", func() {
+			It("should return unauthorized error", func() {
+				reqBody := map[string]string{
+					"encryptionKey": "wrong-key",
+				}
+				jsonBody, _ := json.Marshal(reqBody)
+
+				req := httptest.NewRequest(http.MethodPost, "/encrypt", bytes.NewBuffer(jsonBody))
+				req.Header.Set("Content-Type", "application/json")
+				rec := httptest.NewRecorder()
+				c := e.NewContext(req, rec)
+
+				err := testAPI.EncryptAllFilesHandler(c)
+				Expect(err).NotTo(HaveOccurred())
+				Expect(rec.Code).To(Equal(http.StatusUnauthorized))
+
+				var response map[string]interface{}
+				err = json.Unmarshal(rec.Body.Bytes(), &response)
+				Expect(err).NotTo(HaveOccurred())
+				Expect(response["error"]).To(Equal("Invalid encryption key"))
+			})
+		})
+
+		Context("when encryption key is missing", func() {
+			It("should return bad request error", func() {
+				reqBody := map[string]string{}
+				jsonBody, _ := json.Marshal(reqBody)
+
+				req := httptest.NewRequest(http.MethodPost, "/encrypt", bytes.NewBuffer(jsonBody))
+				req.Header.Set("Content-Type", "application/json")
+				rec := httptest.NewRecorder()
+				c := e.NewContext(req, rec)
+
+				err := testAPI.EncryptAllFilesHandler(c)
+				Expect(err).NotTo(HaveOccurred())
+				Expect(rec.Code).To(Equal(http.StatusBadRequest))
+
+				var response map[string]interface{}
+				err = json.Unmarshal(rec.Body.Bytes(), &response)
+				Expect(err).NotTo(HaveOccurred())
+				Expect(response["error"]).To(Equal("encryptionKey is required"))
+			})
+		})
+
+		Context("when encryption is disabled", func() {
+			It("should return bad request error", func() {
+				// Create API with encryption disabled
+				config := config.Config{
+					Datastore: config.DatastoreConfig{
+						Storage: config.StorageConfig{
+							Mock: true,
+							Encryption: config.EncryptionConfig{
+								Enabled: false,
+							},
+						},
+					},
+				}
+
+				disabledAPI := api.New(&config)
+				disabledAPI.Storage = storage.New(config)
+
+				reqBody := map[string]string{
+					"encryptionKey": "test-encryption-key",
+				}
+				jsonBody, _ := json.Marshal(reqBody)
+
+				req := httptest.NewRequest(http.MethodPost, "/encrypt", bytes.NewBuffer(jsonBody))
+				req.Header.Set("Content-Type", "application/json")
+				rec := httptest.NewRecorder()
+				c := e.NewContext(req, rec)
+
+				err := disabledAPI.EncryptAllFilesHandler(c)
+				Expect(err).NotTo(HaveOccurred())
+				Expect(rec.Code).To(Equal(http.StatusBadRequest))
+
+				var response map[string]interface{}
+				err = json.Unmarshal(rec.Body.Bytes(), &response)
+				Expect(err).NotTo(HaveOccurred())
+				Expect(response["error"]).To(Equal("Encryption is not enabled in configuration"))
+			})
+		})
+
+		Context("when no encryption key is configured", func() {
+			It("should return internal server error", func() {
+				os.Unsetenv("BURRITO_DATASTORE_STORAGE_ENCRYPTION_KEY")
+
+				reqBody := map[string]string{
+					"encryptionKey": "any-key",
+				}
+				jsonBody, _ := json.Marshal(reqBody)
+
+				req := httptest.NewRequest(http.MethodPost, "/encrypt", bytes.NewBuffer(jsonBody))
+				req.Header.Set("Content-Type", "application/json")
+				rec := httptest.NewRecorder()
+				c := e.NewContext(req, rec)
+
+				err := testAPI.EncryptAllFilesHandler(c)
+				Expect(err).NotTo(HaveOccurred())
+				Expect(rec.Code).To(Equal(http.StatusInternalServerError))
+
+				var response map[string]interface{}
+				err = json.Unmarshal(rec.Body.Bytes(), &response)
+				Expect(err).NotTo(HaveOccurred())
+				Expect(response["error"]).To(Equal("No encryption key configured on server"))
+			})
+		})
+
+		Context("when files are already encrypted", func() {
+			It("should skip already encrypted files", func() {
+				// Pre-populate some test data and encrypt it first
+				testAPI.Storage.PutLogs("test-namespace", "test-layer", "test-run", "0", []byte("test logs"))
+				testAPI.Storage.PutPlan("test-namespace", "test-layer", "test-run", "0", "json", []byte("test plan"))
+
+				// First encryption run
+				reqBody := map[string]string{
+					"encryptionKey": "test-encryption-key",
+				}
+				jsonBody, _ := json.Marshal(reqBody)
+
+				req := httptest.NewRequest(http.MethodPost, "/encrypt", bytes.NewBuffer(jsonBody))
+				req.Header.Set("Content-Type", "application/json")
+				rec := httptest.NewRecorder()
+				c := e.NewContext(req, rec)
+
+				err := testAPI.EncryptAllFilesHandler(c)
+				Expect(err).NotTo(HaveOccurred())
+
+				var firstResponse map[string]interface{}
+				err = json.Unmarshal(rec.Body.Bytes(), &firstResponse)
+				Expect(err).NotTo(HaveOccurred())
+
+				// Second encryption run on the same data
+				req2 := httptest.NewRequest(http.MethodPost, "/encrypt", bytes.NewBuffer(jsonBody))
+				req2.Header.Set("Content-Type", "application/json")
+				rec2 := httptest.NewRecorder()
+				c2 := e.NewContext(req2, rec2)
+
+				err = testAPI.EncryptAllFilesHandler(c2)
+				Expect(err).NotTo(HaveOccurred())
+
+				var secondResponse map[string]interface{}
+				err = json.Unmarshal(rec2.Body.Bytes(), &secondResponse)
+				Expect(err).NotTo(HaveOccurred())
+
+				// The second run should encrypt 0 files since they're already encrypted
+				Expect(secondResponse["filesEncrypted"]).To(Equal(float64(0)))
+				Expect(secondResponse["message"]).To(ContainSubstring("0 files encrypted"))
+			})
+		})
+	})
+})

--- a/internal/datastore/datastore.go
+++ b/internal/datastore/datastore.go
@@ -52,6 +52,7 @@ func (s *Datastore) Exec() {
 	api.PUT("/repository/revision/bundle", s.API.PutGitBundleHandler)
 	api.GET("/repository/revision/bundle", s.API.GetGitBundleHandler)
 	api.HEAD("/repository/revision/bundle", s.API.HeadGitBundleHandler)
+	api.POST("/encrypt", s.API.EncryptAllFilesHandler)
 	if s.Config.Datastore.TLS {
 		e.Logger.Fatal(e.StartTLS(s.Config.Datastore.Addr, DefaultCertPath, DefaultKeyPath))
 	} else {

--- a/internal/datastore/storage/encryption.go
+++ b/internal/datastore/storage/encryption.go
@@ -1,0 +1,79 @@
+package storage
+
+import (
+	"fmt"
+	"os"
+
+	"github.com/padok-team/burrito/internal/burrito/config"
+	"github.com/padok-team/burrito/internal/utils/encryption"
+)
+
+type EncryptionManager struct {
+	defaultEncryptor    *encryption.Encryptor
+	namespaceEncryptors map[string]*encryption.Encryptor
+	config              config.EncryptionConfig
+}
+
+func NewEncryptionManager(config config.EncryptionConfig) (*EncryptionManager, error) {
+	em := &EncryptionManager{
+		namespaceEncryptors: make(map[string]*encryption.Encryptor),
+		config:              config,
+	}
+
+	encryptionKey := os.Getenv("BURRITO_DATASTORE_STORAGE_ENCRYPTION_KEY")
+
+	if config.Enabled && encryptionKey == "" {
+		return nil, fmt.Errorf("encryption is enabled but no encryption key is provided in the environment variable BURRITO_DATASTORE_STORAGE_ENCRYPTION_KEY")
+	} else if config.Enabled && encryptionKey != "" {
+		encryptor, err := encryption.NewEncryptor(encryptionKey)
+		if err != nil {
+			return nil, fmt.Errorf("failed to create encryptor: %w", err)
+		}
+		em.defaultEncryptor = encryptor
+	} else {
+		em.defaultEncryptor = nil
+	}
+
+	return em, nil
+}
+
+func (em *EncryptionManager) GetEncryptor(namespace string) *encryption.Encryptor {
+	if encryptor, exists := em.namespaceEncryptors[namespace]; exists {
+		return encryptor
+	}
+
+	return em.defaultEncryptor
+}
+
+// try to get the encryptor for the namespace, if not found, return the default encryptor
+func (em *EncryptionManager) Encrypt(namespace string, plaintext []byte) ([]byte, error) {
+	if em.defaultEncryptor == nil {
+		return plaintext, nil
+	}
+
+	encryptor := em.GetEncryptor(namespace)
+	if encryptor == nil {
+		return plaintext, nil
+	}
+
+	return encryptor.Encrypt(plaintext)
+}
+
+func (em *EncryptionManager) Decrypt(namespace string, ciphertext []byte) ([]byte, error) {
+	if em.defaultEncryptor == nil {
+		return ciphertext, nil
+	}
+
+	encryptor := em.GetEncryptor(namespace)
+	if encryptor == nil {
+		return ciphertext, nil
+	}
+
+	// Try to decrypt the data. If it fails, return the original ciphertext as this might be a migration from an unencrypted state
+	decrypted, err := encryptor.Decrypt(ciphertext)
+	if err != nil {
+		return ciphertext, nil
+	}
+
+	return decrypted, nil
+}

--- a/internal/datastore/storage/encryption_test.go
+++ b/internal/datastore/storage/encryption_test.go
@@ -1,0 +1,152 @@
+package storage
+
+import (
+	"os"
+	"testing"
+
+	"github.com/padok-team/burrito/internal/burrito/config"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestNewEncryptionManager_WithEnvironmentVariable(t *testing.T) {
+	tests := []struct {
+		name            string
+		envKey          string
+		configEnabled   bool
+		configKey       string
+		expectEncryptor bool
+		expectError     bool
+	}{
+		{
+			name:            "encryption enabled with env key set",
+			envKey:          "test-env-key",
+			configEnabled:   true,
+			configKey:       "config-key-should-be-ignored",
+			expectEncryptor: true,
+			expectError:     false,
+		},
+		{
+			name:            "encryption enabled but no env key",
+			envKey:          "",
+			configEnabled:   true,
+			configKey:       "config-key",
+			expectEncryptor: false,
+			expectError:     true, // This should return an error
+		},
+		{
+			name:            "encryption disabled with env key set",
+			envKey:          "test-env-key",
+			configEnabled:   false,
+			configKey:       "",
+			expectEncryptor: false,
+			expectError:     false,
+		},
+		{
+			name:            "encryption disabled and no env key",
+			envKey:          "",
+			configEnabled:   false,
+			configKey:       "",
+			expectEncryptor: false,
+			expectError:     false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			// Setup environment variable
+			if tt.envKey != "" {
+				err := os.Setenv("BURRITO_DATASTORE_STORAGE_ENCRYPTION_KEY", tt.envKey)
+				assert.NoError(t, err)
+				defer os.Unsetenv("BURRITO_DATASTORE_STORAGE_ENCRYPTION_KEY")
+			} else {
+				os.Unsetenv("BURRITO_DATASTORE_STORAGE_ENCRYPTION_KEY")
+			}
+
+			// Create config
+			config := config.EncryptionConfig{
+				Enabled: tt.configEnabled,
+			}
+
+			// Create encryption manager
+			em, err := NewEncryptionManager(config)
+
+			if tt.expectError {
+				assert.Error(t, err)
+				assert.Nil(t, em)
+				return
+			}
+
+			assert.NoError(t, err)
+			assert.NotNil(t, em)
+
+			// Check if encryptor is set as expected
+			if tt.expectEncryptor {
+				assert.NotNil(t, em.defaultEncryptor, "expected default encryptor to be set")
+			} else {
+				assert.Nil(t, em.defaultEncryptor, "expected default encryptor to be nil")
+			}
+		})
+	}
+}
+
+func TestEncryptionManager_EncryptDecrypt(t *testing.T) {
+	// Set environment variable
+	envKey := "test-encryption-key-123"
+	err := os.Setenv("BURRITO_DATASTORE_STORAGE_ENCRYPTION_KEY", envKey)
+	assert.NoError(t, err)
+	defer os.Unsetenv("BURRITO_DATASTORE_STORAGE_ENCRYPTION_KEY")
+
+	// Create config with encryption enabled
+	config := config.EncryptionConfig{
+		Enabled: true,
+	}
+
+	// Create encryption manager
+	em, err := NewEncryptionManager(config)
+	assert.NoError(t, err)
+
+	// Test data
+	namespace := "test-namespace"
+	plaintext := []byte("sensitive terraform state data")
+
+	// Encrypt
+	ciphertext, err := em.Encrypt(namespace, plaintext)
+	assert.NoError(t, err)
+	assert.NotEqual(t, plaintext, ciphertext, "ciphertext should be different from plaintext")
+
+	// Decrypt
+	decrypted, err := em.Decrypt(namespace, ciphertext)
+	assert.NoError(t, err)
+	assert.Equal(t, plaintext, decrypted, "decrypted data should match original")
+}
+
+func TestEncryptionManager_DisabledEncryption(t *testing.T) {
+	// Set environment variable
+	envKey := "test-encryption-key-123"
+	err := os.Setenv("BURRITO_DATASTORE_STORAGE_ENCRYPTION_KEY", envKey)
+	assert.NoError(t, err)
+	defer os.Unsetenv("BURRITO_DATASTORE_STORAGE_ENCRYPTION_KEY")
+
+	// Create config with encryption disabled
+	config := config.EncryptionConfig{
+		Enabled: false,
+	}
+
+	// Create encryption manager
+	em, err := NewEncryptionManager(config)
+	assert.NoError(t, err)
+
+	// Test data
+	namespace := "test-namespace"
+	plaintext := []byte("sensitive terraform state data")
+
+	// Encrypt should return plaintext as-is
+	ciphertext, err := em.Encrypt(namespace, plaintext)
+	assert.NoError(t, err)
+	assert.Equal(t, plaintext, ciphertext, "with encryption disabled, ciphertext should equal plaintext")
+
+	// Decrypt should return ciphertext as-is
+	decrypted, err := em.Decrypt(namespace, ciphertext)
+	assert.NoError(t, err)
+	assert.Equal(t, plaintext, decrypted, "with encryption disabled, decrypted should equal original")
+}

--- a/internal/datastore/storage/mock/mock.go
+++ b/internal/datastore/storage/mock/mock.go
@@ -95,6 +95,30 @@ func (a *Mock) List(prefix string) ([]string, error) {
 	return mapKeys(keySet), nil
 }
 
+// ListRecursive recursively lists all files under a prefix
+func (a *Mock) ListRecursive(prefix string) ([]string, error) {
+	listPrefix := fmt.Sprintf("/%s", utils.SanitizePrefix(prefix))
+	var keys []string
+	found := false
+
+	for k := range a.data {
+		if strings.HasPrefix(k, listPrefix) {
+			keys = append(keys, k)
+			found = true
+		}
+	}
+
+	// Return an error if no keys match the prefix
+	if !found {
+		return nil, &errors.StorageError{
+			Err: fmt.Errorf("prefix %s not found", listPrefix),
+			Nil: true,
+		}
+	}
+
+	return keys, nil
+}
+
 func mapKeys(m map[string]bool) []string {
 	keys := []string{}
 	for k := range m {

--- a/internal/datastore/storage/storage_test.go
+++ b/internal/datastore/storage/storage_test.go
@@ -464,4 +464,73 @@ var _ = Describe("Storage Backends", func() {
 		Entry("S3 backend - Minio", "minio"),
 		Entry("GCS backend", "gcs"),
 	)
+
+	DescribeTable("ListRecursive Operation",
+		func(backendName string) {
+			backend, ok := backends[backendName]
+			if !ok {
+				Skip(fmt.Sprintf("Backend %s is not available", backendName))
+			}
+
+			By("should recursively list all files under a prefix")
+			keys, err := backend.ListRecursive("/layers/ns/layer/run")
+			Expect(err).NotTo(HaveOccurred())
+
+			// Expect all 4 files to be listed recursively
+			Expect(keys).To(HaveLen(4))
+			expectedFiles := []string{
+				"/layers/ns/layer/run/0/run.log",
+				"/layers/ns/layer/run/1/plan.bin",
+				"/layers/ns/layer/run/1/run.log",
+				"/layers/ns/layer/run/1/short.diff",
+			}
+
+			for _, expectedFile := range expectedFiles {
+				Expect(keys).To(ContainElement(expectedFile))
+			}
+
+			By("should recursively list all files under a prefix with trailing slash")
+			keys, err = backend.ListRecursive("/layers/ns/layer/run/")
+			Expect(err).NotTo(HaveOccurred())
+
+			// Expect all 4 files to be listed recursively
+			Expect(keys).To(HaveLen(4))
+			for _, expectedFile := range expectedFiles {
+				Expect(keys).To(ContainElement(expectedFile))
+			}
+
+			By("should recursively list files in a specific run directory")
+			keys, err = backend.ListRecursive("/layers/ns/layer/run/1/")
+			Expect(err).NotTo(HaveOccurred())
+
+			// Expect 3 files in run/1/
+			Expect(keys).To(HaveLen(3))
+			expectedFiles = []string{
+				"/layers/ns/layer/run/1/plan.bin",
+				"/layers/ns/layer/run/1/run.log",
+				"/layers/ns/layer/run/1/short.diff",
+			}
+
+			for _, expectedFile := range expectedFiles {
+				Expect(keys).To(ContainElement(expectedFile))
+			}
+
+			By("should return error for non-existent prefix")
+			nonExistentPrefix := "/layers/non-existent-namespace/non-existent-layer/"
+			keys, err = backend.ListRecursive(nonExistentPrefix)
+
+			Expect(err).To(HaveOccurred(), "ListRecursive operation should fail for non-existent prefix")
+
+			storageErr, ok := err.(*storageErrors.StorageError)
+			Expect(ok).To(BeTrue(), "Error should be a StorageError")
+			Expect(storageErr.Nil).To(BeTrue(), "StorageError.Nil should be true")
+
+			Expect(keys).To(BeNil(), "Keys should be nil when prefix doesn't exist")
+		},
+		Entry("Mock backend", "mock"),
+		Entry("Azure backend", "azure"),
+		Entry("S3 backend - AWS", "aws"),
+		Entry("S3 backend - Minio", "minio"),
+		Entry("GCS backend", "gcs"),
+	)
 })

--- a/internal/utils/encryption/encryption.go
+++ b/internal/utils/encryption/encryption.go
@@ -1,0 +1,131 @@
+package encryption
+
+import (
+	"crypto/aes"
+	"crypto/cipher"
+	"crypto/rand"
+	"crypto/sha256"
+	"fmt"
+	"io"
+)
+
+// Encryptor handles AES256-CBC encryption/decryption operations
+// Compatible with OpenSSL command line tools
+type Encryptor struct {
+	key []byte
+}
+
+// NewEncryptor creates a new encryptor with the given key
+// The key will be hashed to ensure it's exactly 32 bytes for AES256
+func NewEncryptor(key string) (*Encryptor, error) {
+	if key == "" {
+		return nil, fmt.Errorf("encryption key cannot be empty")
+	}
+	hash := sha256.Sum256([]byte(key))
+	return &Encryptor{
+		key: hash[:],
+	}, nil
+}
+
+// Encrypt encrypts plaintext using AES256-CBC
+// Returns the encrypted data with the IV prepended (OpenSSL compatible format)
+func (e *Encryptor) Encrypt(plaintext []byte) ([]byte, error) {
+	block, err := aes.NewCipher(e.key)
+	if err != nil {
+		return nil, fmt.Errorf("failed to create cipher: %w", err)
+	}
+
+	// Apply PKCS#7 padding
+	paddedPlaintext := pkcs7Pad(plaintext, aes.BlockSize)
+
+	// Generate random IV
+	iv := make([]byte, aes.BlockSize)
+	if _, err := io.ReadFull(rand.Reader, iv); err != nil {
+		return nil, fmt.Errorf("failed to generate IV: %w", err)
+	}
+
+	// Create CBC encrypter
+	mode := cipher.NewCBCEncrypter(block, iv)
+
+	// Encrypt the padded plaintext
+	ciphertext := make([]byte, len(paddedPlaintext))
+	mode.CryptBlocks(ciphertext, paddedPlaintext)
+
+	// Prepend IV to ciphertext (OpenSSL format)
+	result := make([]byte, len(iv)+len(ciphertext))
+	copy(result, iv)
+	copy(result[len(iv):], ciphertext)
+
+	return result, nil
+}
+
+// Decrypt decrypts ciphertext using AES256-CBC
+// Expects the IV to be prepended to the ciphertext (OpenSSL compatible format)
+func (e *Encryptor) Decrypt(ciphertext []byte) ([]byte, error) {
+	if len(ciphertext) == 0 {
+		return ciphertext, nil
+	}
+
+	block, err := aes.NewCipher(e.key)
+	if err != nil {
+		return nil, fmt.Errorf("failed to create cipher: %w", err)
+	}
+
+	if len(ciphertext) < aes.BlockSize {
+		return nil, fmt.Errorf("ciphertext too short")
+	}
+
+	if len(ciphertext)%aes.BlockSize != 0 {
+		return nil, fmt.Errorf("ciphertext is not a multiple of the block size")
+	}
+
+	// Extract IV and actual ciphertext
+	iv := ciphertext[:aes.BlockSize]
+	actualCiphertext := ciphertext[aes.BlockSize:]
+
+	// Create CBC decrypter
+	mode := cipher.NewCBCDecrypter(block, iv)
+
+	// Decrypt the ciphertext
+	plaintext := make([]byte, len(actualCiphertext))
+	mode.CryptBlocks(plaintext, actualCiphertext)
+
+	// Remove PKCS#7 padding
+	unpaddedPlaintext, err := pkcs7Unpad(plaintext)
+	if err != nil {
+		return nil, fmt.Errorf("failed to remove padding: %w", err)
+	}
+
+	return unpaddedPlaintext, nil
+}
+
+// pkcs7Pad adds PKCS#7 padding to the data
+func pkcs7Pad(data []byte, blockSize int) []byte {
+	padding := blockSize - len(data)%blockSize
+	padtext := make([]byte, padding)
+	for i := range padtext {
+		padtext[i] = byte(padding)
+	}
+	return append(data, padtext...)
+}
+
+// pkcs7Unpad removes PKCS#7 padding from the data
+func pkcs7Unpad(data []byte) ([]byte, error) {
+	if len(data) == 0 {
+		return nil, fmt.Errorf("data is empty")
+	}
+
+	padding := int(data[len(data)-1])
+	if padding == 0 || padding > len(data) {
+		return nil, fmt.Errorf("invalid padding")
+	}
+
+	// Check if all padding bytes are correct
+	for i := len(data) - padding; i < len(data); i++ {
+		if data[i] != byte(padding) {
+			return nil, fmt.Errorf("invalid padding")
+		}
+	}
+
+	return data[:len(data)-padding], nil
+}

--- a/internal/utils/encryption/encryption_test.go
+++ b/internal/utils/encryption/encryption_test.go
@@ -1,0 +1,236 @@
+package encryption
+
+import (
+	"bytes"
+	"testing"
+)
+
+func TestEncryptor_EncryptDecrypt(t *testing.T) {
+	tests := []struct {
+		name      string
+		key       string
+		plaintext []byte
+	}{
+		{
+			name:      "small text",
+			key:       "test-key-123",
+			plaintext: []byte("hello world"),
+		},
+		{
+			name:      "terraform plan json",
+			key:       "terraform-plan-key",
+			plaintext: []byte(`{"format_version":"1.1","terraform_version":"1.0.0","planned_values":{}}`),
+		},
+		{
+			name:      "large binary data",
+			key:       "binary-key",
+			plaintext: make([]byte, 10000), // 10KB of zeros
+		},
+		{
+			name:      "empty data",
+			key:       "empty-key",
+			plaintext: []byte{},
+		},
+		{
+			name:      "unicode text",
+			key:       "unicode-key",
+			plaintext: []byte("Hello 世界 🌍"),
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			encryptor, err := NewEncryptor(tt.key)
+			if err != nil {
+				t.Fatalf("failed to create encryptor: %v", err)
+			}
+
+			// Encrypt the plaintext
+			ciphertext, err := encryptor.Encrypt(tt.plaintext)
+			if err != nil {
+				t.Fatalf("encryption failed: %v", err)
+			}
+
+			// For non-empty plaintext, ensure ciphertext is different
+			if len(tt.plaintext) > 0 && bytes.Equal(tt.plaintext, ciphertext) {
+				t.Error("ciphertext should be different from plaintext")
+			}
+
+			// Decrypt the ciphertext
+			decrypted, err := encryptor.Decrypt(ciphertext)
+			if err != nil {
+				t.Fatalf("decryption failed: %v", err)
+			}
+
+			// Verify the decrypted data matches the original
+			if !bytes.Equal(tt.plaintext, decrypted) {
+				t.Errorf("decrypted data doesn't match original\noriginal: %v\ndecrypted: %v", tt.plaintext, decrypted)
+			}
+		})
+	}
+}
+
+func TestEncryptor_DifferentKeys(t *testing.T) {
+	plaintext := []byte("sensitive terraform plan data")
+
+	encryptor1, err := NewEncryptor("key1")
+	if err != nil {
+		t.Fatalf("failed to create encryptor1: %v", err)
+	}
+	encryptor2, err := NewEncryptor("key2")
+	if err != nil {
+		t.Fatalf("failed to create encryptor2: %v", err)
+	}
+
+	// Encrypt with first key
+	ciphertext, err := encryptor1.Encrypt(plaintext)
+	if err != nil {
+		t.Fatalf("encryption failed: %v", err)
+	}
+
+	// Try to decrypt with second key (should fail)
+	_, err = encryptor2.Decrypt(ciphertext)
+	if err == nil {
+		t.Error("decryption should fail with different key")
+	}
+}
+
+func TestEncryptor_KeyHashing(t *testing.T) {
+	// Test that different length keys work correctly due to hashing
+	keys := []string{
+		"short",
+		"this-is-a-medium-length-key",
+		"this-is-a-very-long-key-that-exceeds-32-bytes-and-should-be-hashed-properly",
+	}
+
+	plaintext := []byte("test data for key hashing")
+
+	for _, key := range keys {
+		t.Run("key_length_"+string(rune(len(key))), func(t *testing.T) {
+			encryptor, err := NewEncryptor(key)
+			if err != nil {
+				t.Fatalf("failed to create encryptor: %v", err)
+			}
+
+			ciphertext, err := encryptor.Encrypt(plaintext)
+			if err != nil {
+				t.Fatalf("encryption failed: %v", err)
+			}
+
+			decrypted, err := encryptor.Decrypt(ciphertext)
+			if err != nil {
+				t.Fatalf("decryption failed: %v", err)
+			}
+
+			if !bytes.Equal(plaintext, decrypted) {
+				t.Error("decrypted data doesn't match original")
+			}
+		})
+	}
+}
+
+func TestEncryptor_NonceUniqueness(t *testing.T) {
+	encryptor, err := NewEncryptor("test-key")
+	if err != nil {
+		t.Fatalf("failed to create encryptor: %v", err)
+	}
+	plaintext := []byte("same plaintext")
+
+	// Encrypt the same plaintext multiple times
+	ciphertexts := make([][]byte, 10)
+	for i := 0; i < 10; i++ {
+		ciphertext, err := encryptor.Encrypt(plaintext)
+		if err != nil {
+			t.Fatalf("encryption %d failed: %v", i, err)
+		}
+		ciphertexts[i] = ciphertext
+	}
+
+	// Verify all ciphertexts are different (due to random nonces)
+	for i := 0; i < len(ciphertexts); i++ {
+		for j := i + 1; j < len(ciphertexts); j++ {
+			if bytes.Equal(ciphertexts[i], ciphertexts[j]) {
+				t.Errorf("ciphertexts %d and %d should be different", i, j)
+			}
+		}
+	}
+}
+
+func TestEncryptor_InvalidCiphertext(t *testing.T) {
+	encryptor, err := NewEncryptor("test-key")
+	if err != nil {
+		t.Fatalf("failed to create encryptor: %v", err)
+	}
+
+	tests := []struct {
+		name       string
+		ciphertext []byte
+	}{
+		{
+			name:       "too short",
+			ciphertext: []byte("short"),
+		},
+		{
+			name:       "corrupted data",
+			ciphertext: make([]byte, 100), // 100 bytes of zeros
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			_, err := encryptor.Decrypt(tt.ciphertext)
+			if err == nil {
+				t.Error("decryption should fail for invalid ciphertext")
+			}
+		})
+	}
+}
+
+func BenchmarkEncryptor_Encrypt(b *testing.B) {
+	encryptor, err := NewEncryptor("benchmark-key")
+	if err != nil {
+		b.Fatalf("failed to create encryptor: %v", err)
+	}
+	plaintext := make([]byte, 1024) // 1KB
+
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		_, err := encryptor.Encrypt(plaintext)
+		if err != nil {
+			b.Fatal(err)
+		}
+	}
+}
+
+func BenchmarkEncryptor_Decrypt(b *testing.B) {
+	encryptor, err := NewEncryptor("benchmark-key")
+	if err != nil {
+		b.Fatalf("failed to create encryptor: %v", err)
+	}
+	plaintext := make([]byte, 1024) // 1KB
+
+	ciphertext, err := encryptor.Encrypt(plaintext)
+	if err != nil {
+		b.Fatal(err)
+	}
+
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		_, err := encryptor.Decrypt(ciphertext)
+		if err != nil {
+			b.Fatal(err)
+		}
+	}
+}
+
+func TestNewEncryptor_EmptyKey(t *testing.T) {
+	_, err := NewEncryptor("")
+	if err == nil {
+		t.Error("NewEncryptor should return an error for empty key")
+	}
+
+	expectedError := "encryption key cannot be empty"
+	if err.Error() != expectedError {
+		t.Errorf("expected error message '%s', got '%s'", expectedError, err.Error())
+	}
+}


### PR DESCRIPTION
This PR allows to secure datastore content (especially terraform plans) by encrypting files with AES256.
It allows a smooth migration from unencrypted datastores with a specific endpoint. It's also able to work with cleartext/encrypted files to make sure burrito can still work when you'll first enable encryption.

The encryption/decryption is also compatible with openssl so one can operate the files without burrito