### PR TITLE
fix(chart): known_hosts multiline formatting

### DIFF
--- a/deploy/charts/burrito/templates/ssh-known-hosts.yaml
+++ b/deploy/charts/burrito/templates/ssh-known-hosts.yaml
@@ -18,6 +18,6 @@ metadata:
   name: burrito-ssh-known-hosts
   namespace: {{ $namespace }}
 data:
-  known_hosts: 
+  known_hosts: |-
     {{- $.Values.global.sshKnownHosts | nindent 4 }}
 {{- end }}


### PR DESCRIPTION
This PR fixes the multiline formatting for the known_hosts field in the SSH ConfigMap template.

The change replaces the plain `:` with `|-` to properly handle multiline strings in the Helm chart, ensuring SSH known hosts are correctly formatted when deployed.