### PR TITLE
fix(tools): remove terraform-exec

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -166,7 +166,6 @@ require (
 	github.com/google/uuid v1.6.0 // indirect
 	github.com/hashicorp/go-version v1.7.0 // indirect
 	github.com/hashicorp/hcl v1.0.0 // indirect
-	github.com/hashicorp/terraform-exec v0.23.0
 	github.com/inconshreveable/mousetrap v1.1.0 // indirect
 	github.com/josharian/intern v1.0.0 // indirect
 	github.com/json-iterator/go v1.1.12 // indirect

--- a/go.sum
+++ b/go.sum
@@ -272,14 +272,10 @@ github.com/hashicorp/go-retryablehttp v0.7.7 h1:C8hUCYzor8PIfXHa4UrZkU4VvK8o9ISH
 github.com/hashicorp/go-retryablehttp v0.7.7/go.mod h1:pkQpWZeYWskR+D1tR2O5OcBFOxfA7DoAO6xtkuQnHTk=
 github.com/hashicorp/go-version v1.7.0 h1:5tqGy27NaOTB8yJKUZELlFAS/LTKJkrmONwQKeRZfjY=
 github.com/hashicorp/go-version v1.7.0/go.mod h1:fltr4n8CU8Ke44wwGCBoEymUuxUHl09ZGVZPK5anwXA=
-github.com/hashicorp/hc-install v0.9.2 h1:v80EtNX4fCVHqzL9Lg/2xkp62bbvQMnvPQ0G+OmtO24=
-github.com/hashicorp/hc-install v0.9.2/go.mod h1:XUqBQNnuT4RsxoxiM9ZaUk0NX8hi2h+Lb6/c0OZnC/I=
 github.com/hashicorp/hcl v1.0.0 h1:0Anlzjpi4vEasTeNFn2mLJgTSwt0+6sfsiTG8qcWGx4=
 github.com/hashicorp/hcl v1.0.0/go.mod h1:E5yfLk+7swimpb2L/Alb/PJmXilQ/rhwaUYs4T20WEQ=
 github.com/hashicorp/hcl/v2 v2.23.0 h1:Fphj1/gCylPxHutVSEOf2fBOh1VE4AuLV7+kbJf3qos=
 github.com/hashicorp/hcl/v2 v2.23.0/go.mod h1:62ZYHrXgPoX8xBnzl8QzbWq4dyDsDtfCRgIq1rbJEvA=
-github.com/hashicorp/terraform-exec v0.23.0 h1:MUiBM1s0CNlRFsCLJuM5wXZrzA3MnPYEsiXmzATMW/I=
-github.com/hashicorp/terraform-exec v0.23.0/go.mod h1:mA+qnx1R8eePycfwKkCRk3Wy65mwInvlpAeOwmA7vlY=
 github.com/hashicorp/terraform-json v0.25.0 h1:rmNqc/CIfcWawGiwXmRuiXJKEiJu1ntGoxseG1hLhoQ=
 github.com/hashicorp/terraform-json v0.25.0/go.mod h1:sMKS8fiRDX4rVlR6EJUMudg1WcanxCMoWwTLkgZP/vc=
 github.com/inconshreveable/mousetrap v1.1.0 h1:wN+x4NVGpMsO7ErUn/mUI3vEoE6Jt13X2s0bqwp9tc8=

--- a/internal/runner/tools/base/base.go
+++ b/internal/runner/tools/base/base.go
@@ -1,0 +1,78 @@
+package base
+
+import (
+	"errors"
+	"os/exec"
+
+	c "github.com/padok-team/burrito/internal/utils/cmd"
+)
+
+// BaseTool provides common functionality for Terraform and OpenTofu
+type BaseTool struct {
+	ExecPath   string
+	WorkingDir string
+	ToolName   string // "terraform" or "tofu"
+}
+
+func (t *BaseTool) TenvName() string {
+	return t.ToolName
+}
+
+func (t *BaseTool) Init(workingDir string) error {
+	t.WorkingDir = workingDir
+	cmd := exec.Command(t.ExecPath, "init", "-no-color", "-upgrade")
+	c.Verbose(cmd)
+	cmd.Dir = workingDir
+	if err := cmd.Run(); err != nil {
+		return err
+	}
+	return nil
+}
+
+func (t *BaseTool) Plan(planArtifactPath string) error {
+	cmd := exec.Command(t.ExecPath, "plan", "-no-color", "-out", planArtifactPath)
+	c.Verbose(cmd)
+	cmd.Dir = t.WorkingDir
+	if err := cmd.Run(); err != nil {
+		return err
+	}
+	return nil
+}
+
+func (t *BaseTool) Apply(planArtifactPath string) error {
+	var cmd *exec.Cmd
+	if planArtifactPath != "" {
+		cmd = exec.Command(t.ExecPath, "apply", "-no-color", "-auto-approve", planArtifactPath)
+	} else {
+		cmd = exec.Command(t.ExecPath, "apply", "-no-color", "-auto-approve")
+	}
+	c.Verbose(cmd)
+	cmd.Dir = t.WorkingDir
+	if err := cmd.Run(); err != nil {
+		return err
+	}
+	return nil
+}
+
+func (t *BaseTool) Show(planArtifactPath, mode string) ([]byte, error) {
+	var cmd *exec.Cmd
+	switch mode {
+	case "json":
+		cmd = exec.Command(t.ExecPath, "show", "-no-color", "-json", planArtifactPath)
+	case "pretty":
+		cmd = exec.Command(t.ExecPath, "show", "-no-color", planArtifactPath)
+	default:
+		return nil, errors.New("invalid mode")
+	}
+
+	cmd.Dir = t.WorkingDir
+	out, err := cmd.Output()
+	if err != nil {
+		return nil, err
+	}
+	return out, nil
+}
+
+func (t *BaseTool) GetExecPath() string {
+	return t.ExecPath
+}

--- a/internal/runner/tools/install.go
+++ b/internal/runner/tools/install.go
@@ -98,17 +98,13 @@ func InstallBinaries(layer *configv1alpha1.TerraformLayer, repo *configv1alpha1.
 		if err != nil {
 			return nil, err
 		}
-		baseExec = &tf.Terraform{
-			ExecPath: filepath.Join(binaryPath, "Terraform", baseExecVersion, "terraform"),
-		}
+		baseExec = tf.NewTerraform(filepath.Join(binaryPath, "Terraform", baseExecVersion, "terraform"))
 	} else if configv1alpha1.GetOpenTofuEnabled(repo, layer) {
 		baseExecVersion, err = detect(binaryPath, "tofu", configv1alpha1.GetOpenTofuVersion(repo, layer))
 		if err != nil {
 			return nil, err
 		}
-		baseExec = &ot.OpenTofu{
-			ExecPath: filepath.Join(binaryPath, "OpenTofu", baseExecVersion, "tofu"),
-		}
+		baseExec = ot.NewOpenTofu(filepath.Join(binaryPath, "OpenTofu", baseExecVersion, "tofu"))
 	} else {
 		return nil, errors.New("Please enable either Terraform or OpenTofu in the repository or layer configuration")
 	}

--- a/internal/runner/tools/opentofu/opentofu.go
+++ b/internal/runner/tools/opentofu/opentofu.go
@@ -1,79 +1,18 @@
 package opentofu
 
 import (
-	"errors"
-	"os/exec"
-
-	c "github.com/padok-team/burrito/internal/utils/cmd"
+	"github.com/padok-team/burrito/internal/runner/tools/base"
 )
 
-// The equivalent of tfexec for OpenTofu is not actively maintained.
-// Switch to it when this repo is updated: https://github.com/tofu/tofu-exec
-
 type OpenTofu struct {
-	ExecPath   string
-	WorkingDir string
+	base.BaseTool
 }
 
-func (t *OpenTofu) TenvName() string {
-	return "tofu"
-}
-
-func (t *OpenTofu) Init(workingDir string) error {
-	t.WorkingDir = workingDir
-	cmd := exec.Command(t.ExecPath, "init", "-no-color", "-upgrade")
-	c.Verbose(cmd)
-	cmd.Dir = workingDir
-	if err := cmd.Run(); err != nil {
-		return err
+func NewOpenTofu(execPath string) *OpenTofu {
+	return &OpenTofu{
+		BaseTool: base.BaseTool{
+			ExecPath: execPath,
+			ToolName: "tofu",
+		},
 	}
-	return nil
-}
-
-func (t *OpenTofu) Plan(planArtifactPath string) error {
-	cmd := exec.Command(t.ExecPath, "plan", "-no-color", "-out", planArtifactPath)
-	c.Verbose(cmd)
-	cmd.Dir = t.WorkingDir
-	if err := cmd.Run(); err != nil {
-		return err
-	}
-	return nil
-}
-
-func (t *OpenTofu) Apply(planArtifactPath string) error {
-	var cmd *exec.Cmd
-	if planArtifactPath != "" {
-		cmd = exec.Command(t.ExecPath, "apply", "-no-color", "-auto-approve", planArtifactPath)
-	} else {
-		cmd = exec.Command(t.ExecPath, "apply", "-no-color", "-auto-approve")
-	}
-	c.Verbose(cmd)
-	cmd.Dir = t.WorkingDir
-	if err := cmd.Run(); err != nil {
-		return err
-	}
-	return nil
-}
-
-func (t *OpenTofu) Show(planArtifactPath, mode string) ([]byte, error) {
-	var cmd *exec.Cmd
-	switch mode {
-	case "json":
-		cmd = exec.Command(t.ExecPath, "show", "-no-color", "-json", planArtifactPath)
-	case "pretty":
-		cmd = exec.Command(t.ExecPath, "show", "-no-color", planArtifactPath)
-	default:
-		return nil, errors.New("invalid mode")
-	}
-
-	cmd.Dir = t.WorkingDir
-	out, err := cmd.Output()
-	if err != nil {
-		return nil, err
-	}
-	return out, nil
-}
-
-func (t *OpenTofu) GetExecPath() string {
-	return t.ExecPath
 }

--- a/internal/runner/tools/terraform/terraform.go
+++ b/internal/runner/tools/terraform/terraform.go
@@ -1,94 +1,18 @@
 package terraform
 
 import (
-	"context"
-	"encoding/json"
-	"errors"
-	"io"
-	"os"
-
-	"github.com/hashicorp/terraform-exec/tfexec"
+	"github.com/padok-team/burrito/internal/runner/tools/base"
 )
 
 type Terraform struct {
-	exec     *tfexec.Terraform
-	ExecPath string
+	base.BaseTool
 }
 
-func (t *Terraform) TenvName() string {
-	return "terraform"
-}
-
-func (t *Terraform) Init(workingDir string) error {
-	exec, err := tfexec.NewTerraform(workingDir, t.ExecPath)
-	if err != nil {
-		return err
+func NewTerraform(execPath string) *Terraform {
+	return &Terraform{
+		BaseTool: base.BaseTool{
+			ExecPath: execPath,
+			ToolName: "terraform",
+		},
 	}
-	t.exec = exec
-	err = t.exec.Init(context.Background(), tfexec.Upgrade(true))
-	if err != nil {
-		return err
-	}
-	return nil
-}
-
-func (t *Terraform) Plan(planArtifactPath string) error {
-	t.verbose()
-	_, err := t.exec.Plan(context.Background(), tfexec.Out(planArtifactPath))
-	if err != nil {
-		return err
-	}
-	return nil
-}
-
-func (t *Terraform) Apply(planArtifactPath string) error {
-	t.verbose()
-	applyOpts := []tfexec.ApplyOption{}
-	if planArtifactPath != "" {
-		applyOpts = append(applyOpts, tfexec.DirOrPlan(planArtifactPath))
-	}
-
-	err := t.exec.Apply(context.Background(), applyOpts...)
-	if err != nil {
-		return err
-	}
-	return nil
-}
-
-func (t *Terraform) Show(planArtifactPath, mode string) ([]byte, error) {
-	t.silent()
-	switch mode {
-	case "json":
-		planJson, err := t.exec.ShowPlanFile(context.TODO(), planArtifactPath)
-		if err != nil {
-			return nil, err
-		}
-		planJsonBytes, err := json.Marshal(planJson)
-		if err != nil {
-			return nil, err
-		}
-		return planJsonBytes, nil
-	case "pretty":
-		plan, err := t.exec.ShowPlanFileRaw(context.TODO(), planArtifactPath)
-		if err != nil {
-			return nil, err
-		}
-		return []byte(plan), nil
-	default:
-		return nil, errors.New("invalid mode")
-	}
-}
-
-func (t *Terraform) GetExecPath() string {
-	return t.ExecPath
-}
-
-func (t *Terraform) silent() {
-	t.exec.SetStdout(io.Discard)
-	t.exec.SetStderr(io.Discard)
-}
-
-func (t *Terraform) verbose() {
-	t.exec.SetStdout(os.Stdout)
-	t.exec.SetStderr(os.Stderr)
 }


### PR DESCRIPTION
Fix https://github.com/padok-team/burrito/issues/598

Changes made:
- Replaced terraform-exec library: Migrated from hashicorp/terraform-exec to direct os/exec commands
- Created shared base: New internal/runner/tools/base/base.go with BaseTool struct containing all common functionality