### PR TITLE
docs: add multi-versioning doc

### DIFF
--- a/.github/workflows/docs.yaml
+++ b/.github/workflows/docs.yaml
@@ -3,6 +3,8 @@ on:
   push:
     branches:
       - main
+    tags:
+      - v*
   pull_request:
     branches:
       - main
@@ -28,7 +30,8 @@ jobs:
           restore-keys: |
             mkdocs-material-
 
-      - run: pip install mkdocs-material
+      - name: Install dependencies
+        run: pip install mkdocs-material mike
 
       - name: Lint Markdown files
         uses: DavidAnson/markdownlint-cli2-action@v19
@@ -39,6 +42,18 @@ jobs:
       - name: Build pages
         run: mkdocs build --strict
 
-      - name: Deploy pages
-        run: mkdocs gh-deploy --strict --force
+      - name: Configure Git user
+        run: |
+          git config --local user.email "github-actions[bot]@users.noreply.github.com"
+          git config --local user.name "github-actions[bot]"
+
+      - name: Deploy pages (unstable)
         if: github.ref == 'refs/heads/main'
+        run: mike deploy --push --update-aliases unstable
+
+      - name: Deploy pages (new release)
+        if: startsWith(github.ref, 'refs/tags/')
+        run: |
+          mike deploy --push --update-aliases ${{ github.ref_name }} latest
+          mike set-default --push latest
+          echo "Deployed version ${{ github.ref_name }} to GitHub Pages"

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -6,6 +6,9 @@ theme:
   logo: assets/icon/burrito.png
   features:
     - navigation.indexes
+extra:
+  version:
+    provider: mike
 markdown_extensions:
 - codehilite
 - admonition


### PR DESCRIPTION
Fixes #593

For each release it deploys a new version linked to the release name and update the "latest" alias.

For each push on the main branch it pushes a new version of the doc under the "unstable" alias.

By default, visitors of https://docs.burrito.tf will be presented the "latest" version of the documentation.

Once this PR merged I will push a version of the doc for 0.7.0/latest from the tag v0.7.0