### PR TITLE
feat: add manual apply now action

### DIFF
--- a/internal/annotations/annotations.go
+++ b/internal/annotations/annotations.go
@@ -28,6 +28,7 @@ const (
 	AdditionnalTriggerPaths string = "config.terraform.padok.cloud/additionnal-trigger-paths"
 
 	SyncNow        string = "api.terraform.padok.cloud/sync-now"
+	ApplyNow       string = "api.terraform.padok.cloud/apply-now"
 	AllowedTenants string = "credentials.terraform.padok.cloud/allowed-tenants"
 )
 

--- a/internal/controllers/terraformlayer/testdata/manual-apply-case.yaml
+++ b/internal/controllers/terraformlayer/testdata/manual-apply-case.yaml
@@ -1,0 +1,26 @@
+apiVersion: config.terraform.padok.cloud/v1alpha1
+kind: TerraformLayer
+metadata:
+  name: manual-apply-case-1
+  namespace: default
+  annotations:
+    api.terraform.padok.cloud/apply-now: "true"
+    webhook.terraform.padok.cloud/relevant-commit: ca9b6c80ac8fb5cd837ae9b374b79ff33f472558
+    runner.terraform.padok.cloud/plan-commit: ca9b6c80ac8fb5cd837ae9b374b79ff33f472558
+    runner.terraform.padok.cloud/plan-date: Sun May  8 11:21:53 UTC 2023
+    runner.terraform.padok.cloud/plan-run: run-succeeded/0
+    runner.terraform.padok.cloud/plan-sum: AuP6pMNxWsbSZKnxZvxD842wy0qaF9JCX8HW1nFeL1I=
+spec:
+  branch: main
+  path: manual-apply-case/
+  remediationStrategy:
+    autoApply: false
+  repository:
+    name: burrito
+    namespace: default
+  terraform:
+    enabled: true
+    version: 1.3.1
+  terragrunt:
+    enabled: true
+    version: 0.45.4

--- a/internal/server/api/api_test.go
+++ b/internal/server/api/api_test.go
@@ -1,0 +1,32 @@
+package api_test
+
+import (
+	"testing"
+
+	"github.com/labstack/echo/v4"
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+
+	configv1alpha1 "github.com/padok-team/burrito/api/v1alpha1"
+	"k8s.io/apimachinery/pkg/runtime"
+)
+
+func TestServerAPI(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "Server API Suite")
+}
+
+func newScheme() *runtime.Scheme {
+	s := runtime.NewScheme()
+	_ = configv1alpha1.AddToScheme(s)
+	return s
+}
+
+func setRouteParams(c echo.Context, names []string, values []string) {
+	c.SetParamNames(names...)
+	c.SetParamValues(values...)
+}
+
+func boolPtr(b bool) *bool {
+	return &b
+}

--- a/internal/server/api/layers_test.go
+++ b/internal/server/api/layers_test.go
@@ -1,0 +1,135 @@
+package api_test
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+
+	"github.com/labstack/echo/v4"
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+
+	configv1alpha1 "github.com/padok-team/burrito/api/v1alpha1"
+	"github.com/padok-team/burrito/internal/annotations"
+	"github.com/padok-team/burrito/internal/server/api"
+	"github.com/padok-team/burrito/internal/server/utils"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+var _ = Describe("Layers API", func() {
+	var e *echo.Echo
+
+	BeforeEach(func() {
+		e = echo.New()
+	})
+
+	Describe("LayersHandler", func() {
+		It("should return layers with hasValidPlan, manualSyncStatus, and autoApply computed correctly", func() {
+			// Layer with a valid plan + apply-now annotation + autoApply
+			layerWithPlanAndApply := &configv1alpha1.TerraformLayer{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "layer-with-plan",
+					Namespace: "default",
+					Annotations: map[string]string{
+						annotations.LastPlanSum: "AuP6pMNxWsbSZKnxZvxD842wy0qaF9JCX8HW1nFeL1I=",
+						annotations.ApplyNow:    "true",
+					},
+				},
+				Spec: configv1alpha1.TerraformLayerSpec{
+					Path:   "modules/vpc",
+					Branch: "main",
+					Repository: configv1alpha1.TerraformLayerRepository{
+						Name:      "my-repo",
+						Namespace: "default",
+					},
+				},
+			}
+
+			// Layer without plan sum + sync-now annotation + autoApply false
+			layerWithoutPlan := &configv1alpha1.TerraformLayer{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "layer-no-plan",
+					Namespace: "default",
+					Annotations: map[string]string{
+						annotations.SyncNow: "true",
+					},
+				},
+				Spec: configv1alpha1.TerraformLayerSpec{
+					Path:   "modules/rds",
+					Branch: "main",
+					Repository: configv1alpha1.TerraformLayerRepository{
+						Name:      "my-repo",
+						Namespace: "default",
+					},
+					RemediationStrategy: configv1alpha1.RemediationStrategy{
+						AutoApply: boolPtr(false),
+					},
+				},
+			}
+
+			repo := &configv1alpha1.TerraformRepository{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "my-repo",
+					Namespace: "default",
+				},
+				Spec: configv1alpha1.TerraformRepositorySpec{
+					RemediationStrategy: configv1alpha1.RemediationStrategy{
+						AutoApply: boolPtr(true),
+					},
+				},
+			}
+
+			fakeClient := fake.NewClientBuilder().
+				WithScheme(newScheme()).
+				WithObjects(layerWithPlanAndApply, layerWithoutPlan, repo).
+				Build()
+
+			a := &api.API{Client: fakeClient}
+
+			req := httptest.NewRequest(http.MethodGet, "/api/layers", nil)
+			rec := httptest.NewRecorder()
+			c := e.NewContext(req, rec)
+
+			err := a.LayersHandler(c)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(rec.Code).To(Equal(http.StatusOK))
+
+			var resp struct {
+				Results []struct {
+					Name             string                 `json:"name"`
+					HasValidPlan     bool                   `json:"hasValidPlan"`
+					ManualSyncStatus utils.ManualSyncStatus `json:"manualSyncStatus"`
+					AutoApply        bool                   `json:"autoApply"`
+				} `json:"results"`
+			}
+			Expect(json.Unmarshal(rec.Body.Bytes(), &resp)).NotTo(HaveOccurred())
+			Expect(resp.Results).To(HaveLen(2))
+
+			// Find each layer in results (order not guaranteed)
+			byName := map[string]struct {
+				HasValidPlan     bool
+				ManualSyncStatus utils.ManualSyncStatus
+				AutoApply        bool
+			}{}
+			for _, r := range resp.Results {
+				byName[r.Name] = struct {
+					HasValidPlan     bool
+					ManualSyncStatus utils.ManualSyncStatus
+					AutoApply        bool
+				}{r.HasValidPlan, r.ManualSyncStatus, r.AutoApply}
+			}
+
+			// layer-with-plan: has plan sum → hasValidPlan=true, apply-now → manualSyncStatus=annotated, repo autoApply=true
+			Expect(byName["layer-with-plan"].HasValidPlan).To(BeTrue())
+			Expect(byName["layer-with-plan"].ManualSyncStatus).To(Equal(utils.ManualSyncAnnotated))
+			Expect(byName["layer-with-plan"].AutoApply).To(BeTrue())
+
+			// layer-no-plan: no plan sum → hasValidPlan=false, sync-now → manualSyncStatus=annotated, repo autoApply=true (inherited)
+			Expect(byName["layer-no-plan"].HasValidPlan).To(BeFalse())
+			Expect(byName["layer-no-plan"].ManualSyncStatus).To(Equal(utils.ManualSyncAnnotated))
+			Expect(byName["layer-no-plan"].AutoApply).To(BeFalse())
+		})
+	})
+})

--- a/internal/server/api/sync_test.go
+++ b/internal/server/api/sync_test.go
@@ -1,0 +1,234 @@
+package api_test
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+
+	"github.com/labstack/echo/v4"
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+
+	configv1alpha1 "github.com/padok-team/burrito/api/v1alpha1"
+	"github.com/padok-team/burrito/internal/annotations"
+	"github.com/padok-team/burrito/internal/server/api"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+)
+
+var _ = Describe("Sync API", func() {
+	var e *echo.Echo
+
+	BeforeEach(func() {
+		e = echo.New()
+	})
+
+	Describe("ApplyLayerHandler", func() {
+		It("should trigger apply on an existing layer", func() {
+			layer := &configv1alpha1.TerraformLayer{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:        "my-layer",
+					Namespace:   "default",
+					Annotations: map[string]string{},
+				},
+				Spec: configv1alpha1.TerraformLayerSpec{
+					Path:   "modules/test",
+					Branch: "main",
+				},
+			}
+
+			fakeClient := fake.NewClientBuilder().
+				WithScheme(newScheme()).
+				WithObjects(layer).
+				Build()
+
+			a := &api.API{Client: fakeClient}
+
+			req := httptest.NewRequest(http.MethodPost, "/api/layers/default/my-layer/apply", nil)
+			rec := httptest.NewRecorder()
+			c := e.NewContext(req, rec)
+			setRouteParams(c, []string{"namespace", "layer"}, []string{"default", "my-layer"})
+
+			err := a.ApplyLayerHandler(c)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(rec.Code).To(Equal(http.StatusOK))
+
+			var body map[string]string
+			Expect(json.Unmarshal(rec.Body.Bytes(), &body)).NotTo(HaveOccurred())
+			Expect(body["status"]).To(Equal("Layer apply triggered"))
+		})
+
+		It("should return error when layer does not exist", func() {
+			fakeClient := fake.NewClientBuilder().
+				WithScheme(newScheme()).
+				Build()
+
+			a := &api.API{Client: fakeClient}
+
+			req := httptest.NewRequest(http.MethodPost, "/api/layers/default/nonexistent/apply", nil)
+			rec := httptest.NewRecorder()
+			c := e.NewContext(req, rec)
+			setRouteParams(c, []string{"namespace", "layer"}, []string{"default", "nonexistent"})
+
+			err := a.ApplyLayerHandler(c)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(rec.Code).To(Equal(http.StatusInternalServerError))
+		})
+
+		It("should return conflict when layer is managed by TerraformPullRequest", func() {
+			layer := &configv1alpha1.TerraformLayer{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "pr-layer",
+					Namespace: "default",
+					Labels: map[string]string{
+						"burrito/managed-by": "terraform-pullrequest",
+					},
+					Annotations: map[string]string{},
+				},
+				Spec: configv1alpha1.TerraformLayerSpec{
+					Path:   "modules/test",
+					Branch: "main",
+				},
+			}
+
+			fakeClient := fake.NewClientBuilder().
+				WithScheme(newScheme()).
+				WithObjects(layer).
+				Build()
+
+			a := &api.API{Client: fakeClient}
+
+			req := httptest.NewRequest(http.MethodPost, "/api/layers/default/pr-layer/apply", nil)
+			rec := httptest.NewRecorder()
+			c := e.NewContext(req, rec)
+			setRouteParams(c, []string{"namespace", "layer"}, []string{"default", "pr-layer"})
+
+			err := a.ApplyLayerHandler(c)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(rec.Code).To(Equal(http.StatusConflict))
+
+			var body map[string]string
+			Expect(json.Unmarshal(rec.Body.Bytes(), &body)).NotTo(HaveOccurred())
+			Expect(body["error"]).To(ContainSubstring("Manual apply is not allowed"))
+		})
+
+		It("should not block when managed-by label exists but is empty", func() {
+			layer := &configv1alpha1.TerraformLayer{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "empty-label-layer",
+					Namespace: "default",
+					Labels: map[string]string{
+						"burrito/managed-by": "",
+					},
+					Annotations: map[string]string{},
+				},
+				Spec: configv1alpha1.TerraformLayerSpec{
+					Path:   "modules/test",
+					Branch: "main",
+				},
+			}
+
+			fakeClient := fake.NewClientBuilder().
+				WithScheme(newScheme()).
+				WithObjects(layer).
+				Build()
+
+			a := &api.API{Client: fakeClient}
+
+			req := httptest.NewRequest(http.MethodPost, "/api/layers/default/empty-label-layer/apply", nil)
+			rec := httptest.NewRecorder()
+			c := e.NewContext(req, rec)
+			setRouteParams(c, []string{"namespace", "layer"}, []string{"default", "empty-label-layer"})
+
+			err := a.ApplyLayerHandler(c)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(rec.Code).To(Equal(http.StatusOK))
+		})
+	})
+
+	Describe("SyncLayerHandler", func() {
+		It("should trigger sync on an existing layer", func() {
+			layer := &configv1alpha1.TerraformLayer{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:        "sync-layer",
+					Namespace:   "default",
+					Annotations: map[string]string{},
+				},
+				Spec: configv1alpha1.TerraformLayerSpec{
+					Path:   "modules/test",
+					Branch: "main",
+				},
+			}
+
+			fakeClient := fake.NewClientBuilder().
+				WithScheme(newScheme()).
+				WithObjects(layer).
+				Build()
+
+			a := &api.API{Client: fakeClient}
+
+			req := httptest.NewRequest(http.MethodPost, "/api/layers/default/sync-layer/sync", nil)
+			rec := httptest.NewRecorder()
+			c := e.NewContext(req, rec)
+			setRouteParams(c, []string{"namespace", "layer"}, []string{"default", "sync-layer"})
+
+			err := a.SyncLayerHandler(c)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(rec.Code).To(Equal(http.StatusOK))
+
+			var body map[string]string
+			Expect(json.Unmarshal(rec.Body.Bytes(), &body)).NotTo(HaveOccurred())
+			Expect(body["status"]).To(Equal("Layer sync triggered"))
+		})
+
+		It("should return conflict when sync is already pending", func() {
+			layer := &configv1alpha1.TerraformLayer{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "already-syncing",
+					Namespace: "default",
+					Annotations: map[string]string{
+						annotations.SyncNow: "true",
+					},
+				},
+				Spec: configv1alpha1.TerraformLayerSpec{
+					Path:   "modules/test",
+					Branch: "main",
+				},
+			}
+
+			fakeClient := fake.NewClientBuilder().
+				WithScheme(newScheme()).
+				WithObjects(layer).
+				Build()
+
+			a := &api.API{Client: fakeClient}
+
+			req := httptest.NewRequest(http.MethodPost, "/api/layers/default/already-syncing/sync", nil)
+			rec := httptest.NewRecorder()
+			c := e.NewContext(req, rec)
+			setRouteParams(c, []string{"namespace", "layer"}, []string{"default", "already-syncing"})
+
+			err := a.SyncLayerHandler(c)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(rec.Code).To(Equal(http.StatusConflict))
+		})
+
+		It("should return error when layer does not exist", func() {
+			fakeClient := fake.NewClientBuilder().
+				WithScheme(newScheme()).
+				Build()
+
+			a := &api.API{Client: fakeClient}
+
+			req := httptest.NewRequest(http.MethodPost, "/api/layers/default/nonexistent/sync", nil)
+			rec := httptest.NewRecorder()
+			c := e.NewContext(req, rec)
+			setRouteParams(c, []string{"namespace", "layer"}, []string{"default", "nonexistent"})
+
+			err := a.SyncLayerHandler(c)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(rec.Code).To(Equal(http.StatusInternalServerError))
+		})
+	})
+
+})

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -168,6 +168,7 @@ func (s *Server) Exec() {
 	api.Use(middleware.RequestLoggerWithConfig(utils.LoggerMiddlewareConfig))
 	api.GET("/layers", s.API.LayersHandler)
 	api.POST("/layers/:namespace/:layer/sync", s.API.SyncLayerHandler)
+	api.POST("/layers/:namespace/:layer/apply", s.API.ApplyLayerHandler)
 	api.GET("/repositories", s.API.RepositoriesHandler)
 	api.GET("/logs/:namespace/:layer/:run/:attempt", s.API.GetLogsHandler)
 	api.GET("/run/:namespace/:layer/:run/attempts", s.API.GetAttemptsHandler)

--- a/internal/server/utils/manual_sync.go
+++ b/internal/server/utils/manual_sync.go
@@ -25,3 +25,16 @@ func GetManualSyncStatus(layer configv1alpha1.TerraformLayer) ManualSyncStatus {
 	}
 	return ManualSyncNone
 }
+
+func GetManualApplyStatus(layer configv1alpha1.TerraformLayer) ManualSyncStatus {
+	if layer.Annotations[annotations.ApplyNow] == "true" {
+		return ManualSyncAnnotated
+	}
+	// check the IsApplyScheduled condition on layer
+	for _, c := range layer.Status.Conditions {
+		if c.Type == "IsApplyScheduled" && c.Status == "True" {
+			return ManualSyncPending
+		}
+	}
+	return ManualSyncNone
+}

--- a/ui/src/assets/icons/PlayIcon.tsx
+++ b/ui/src/assets/icons/PlayIcon.tsx
@@ -1,0 +1,21 @@
+import type { SVGProps } from 'react';
+
+const PlayIcon = (props: SVGProps<SVGSVGElement>) => (
+  <svg
+    xmlns="http://www.w3.org/2000/svg"
+    width={24}
+    height={24}
+    viewBox="0 0 24 24"
+    fill="none"
+    {...props}
+  >
+    <path
+      d="M6 4.75L18 12L6 19.25V4.75Z"
+      strokeWidth={1.5}
+      strokeLinecap="round"
+      strokeLinejoin="round"
+    />
+  </svg>
+);
+
+export default PlayIcon;

--- a/ui/src/assets/icons/SyncIcon.tsx
+++ b/ui/src/assets/icons/SyncIcon.tsx
@@ -1,4 +1,4 @@
-import { SVGProps } from 'react';
+import type { SVGProps } from 'react';
 
 const SyncIcon = (props: SVGProps<SVGSVGElement>) => (
   <svg height={24} width={24} viewBox="0 0 24 24" {...props}>

--- a/ui/src/clients/layers/client.ts
+++ b/ui/src/clients/layers/client.ts
@@ -15,3 +15,10 @@ export const syncLayer = async (namespace: string, name: string) => {
   );
   return response;
 };
+
+export const applyLayer = async (namespace: string, name: string) => {
+  const response = await axios.post(
+    `${import.meta.env.VITE_API_BASE_URL}/layers/${namespace}/${name}/apply`
+  );
+  return response;
+};

--- a/ui/src/clients/layers/types.ts
+++ b/ui/src/clients/layers/types.ts
@@ -17,6 +17,8 @@ export type Layer = {
   isRunning: boolean;
   manualSyncStatus: ManualSyncStatus;
   isPR: boolean;
+  hasValidPlan: boolean;
+  autoApply: boolean;
 };
 
 export type LayerState = 'success' | 'warning' | 'error' | 'disabled';

--- a/ui/src/clients/layers/utils.ts
+++ b/ui/src/clients/layers/utils.ts
@@ -1,0 +1,24 @@
+import type { Layer } from './types';
+
+export const getApplyTooltip = (layer: Layer) => {
+  if (layer.isPR) {
+    return 'Manual apply is not allowed on pull request layers';
+  }
+  if (layer.manualSyncStatus !== 'none') {
+    return 'Run in progress...';
+  }
+  if (!layer.hasValidPlan) {
+    return 'No valid plan available. Run a plan first before applying.';
+  }
+  return 'Apply';
+};
+
+export const getSyncTooltip = (layer: Layer) => {
+  if (layer.manualSyncStatus !== 'none') {
+    return 'Run in progress...';
+  }
+  if (layer.autoApply) {
+    return 'Sync';
+  }
+  return 'Plan';
+};

--- a/ui/src/components/cards/Card.tsx
+++ b/ui/src/components/cards/Card.tsx
@@ -1,4 +1,4 @@
-import React, { useState } from 'react';
+import React, { useEffect, useState } from 'react';
 import { twMerge } from 'tailwind-merge';
 import { Tooltip } from 'react-tooltip';
 
@@ -9,10 +9,12 @@ import CodeBranchIcon from '@/assets/icons/CodeBranchIcon';
 import ChiliLight from '@/assets/illustrations/ChiliLight';
 import ChiliDark from '@/assets/illustrations/ChiliDark';
 
-import { Layer } from '@/clients/layers/types';
+import type { Layer } from '@/clients/layers/types';
 import GenericIconButton from '../buttons/GenericIconButton';
-import { syncLayer } from '@/clients/layers/client';
+import { applyLayer, syncLayer } from '@/clients/layers/client';
+import { getApplyTooltip, getSyncTooltip } from '@/clients/layers/utils';
 import SyncIcon from '@/assets/icons/SyncIcon';
+import PlayIcon from '@/assets/icons/PlayIcon';
 
 export interface CardProps {
   className?: string;
@@ -77,14 +79,24 @@ const Card: React.FC<CardProps> = ({
   const syncSelectedLayer = async (layer: Layer) => {
     const sync = await syncLayer(layer.namespace, layer.name);
     if (sync.status === 200) {
-      setIsManualSyncPending(true);
+      setIsManualActionPending(true);
     }
   };
 
-  const [isManualSyncPending, setIsManualSyncPending] = useState(
-    layer.manualSyncStatus === 'pending' ||
-      layer.manualSyncStatus === 'annotated'
+  const applySelectedLayer = async (layer: Layer) => {
+    const apply = await applyLayer(layer.namespace, layer.name);
+    if (apply.status === 200) {
+      setIsManualActionPending(true);
+    }
+  };
+
+  const [isManualActionPending, setIsManualActionPending] = useState(
+    layer.manualSyncStatus !== 'none'
   );
+
+  useEffect(() => {
+    setIsManualActionPending(layer.manualSyncStatus !== 'none');
+  }, [layer.manualSyncStatus, layer.lastRunAt]);
 
   return (
     <div
@@ -181,10 +193,19 @@ const Card: React.FC<CardProps> = ({
         <GenericIconButton
           variant={variant}
           Icon={SyncIcon}
-          disabled={isManualSyncPending}
+          disabled={isManualActionPending}
           onClick={() => syncSelectedLayer(layer)}
-          tooltip={isManualSyncPending ? 'Sync in progress...' : 'Sync now'}
+          tooltip={getSyncTooltip(layer)}
         />
+        {!layer.autoApply && (
+          <GenericIconButton
+            variant={variant}
+            Icon={PlayIcon}
+            disabled={layer.isPR || isManualActionPending}
+            onClick={() => applySelectedLayer(layer)}
+            tooltip={getApplyTooltip(layer)}
+          />
+        )}
       </div>
       <Tooltip
         opacity={1}

--- a/ui/src/components/tables/Table.tsx
+++ b/ui/src/components/tables/Table.tsx
@@ -16,10 +16,12 @@ import ChiliLight from '@/assets/illustrations/ChiliLight';
 import ChiliDark from '@/assets/illustrations/ChiliDark';
 import CodeBranchIcon from '@/assets/icons/CodeBranchIcon';
 import SyncIcon from '@/assets/icons/SyncIcon';
+import PlayIcon from '@/assets/icons/PlayIcon';
 import GenericIconButton from '@/components/buttons/GenericIconButton';
 
 import { Layer, LayerState } from '@/clients/layers/types';
-import { syncLayer } from '@/clients/layers/client';
+import { applyLayer, syncLayer } from '@/clients/layers/client';
+import { getApplyTooltip, getSyncTooltip } from '@/clients/layers/utils';
 
 export interface TableProps {
   className?: string;
@@ -39,6 +41,13 @@ const Table: React.FC<TableProps> = ({
   const syncSelectedLayer = async (index: number) => {
     const sync = await syncLayer(data[index].namespace, data[index].name);
     if (sync.status === 200) {
+      data[index].manualSyncStatus = 'pending';
+    }
+  };
+
+  const applySelectedLayer = async (index: number) => {
+    const apply = await applyLayer(data[index].namespace, data[index].name);
+    if (apply.status === 200) {
       data[index].manualSyncStatus = 'pending';
     }
   };
@@ -101,18 +110,22 @@ const Table: React.FC<TableProps> = ({
               <GenericIconButton
                 variant={variant}
                 Icon={SyncIcon}
-                disabled={
-                  result.row.original.manualSyncStatus === 'pending' ||
-                  result.row.original.manualSyncStatus === 'annotated'
-                }
+                disabled={result.row.original.manualSyncStatus !== 'none'}
                 onClick={() => syncSelectedLayer(result.row.index)}
-                tooltip={
-                  result.row.original.manualSyncStatus === 'pending' ||
-                  result.row.original.manualSyncStatus === 'annotated'
-                    ? 'Sync in progress...'
-                    : 'Sync now'
-                }
+                tooltip={getSyncTooltip(result.row.original)}
               />
+              {!result.row.original.autoApply && (
+                <GenericIconButton
+                  variant={variant}
+                  Icon={PlayIcon}
+                  disabled={
+                    result.row.original.isPR ||
+                    result.row.original.manualSyncStatus !== 'none'
+                  }
+                  onClick={() => applySelectedLayer(result.row.index)}
+                  tooltip={getApplyTooltip(result.row.original)}
+                />
+              )}
             </div>
           ) : result.row.original.isRunning ? (
             <div


### PR DESCRIPTION
Hi team,

This PR adds a manual "Apply Now" feature, allowing users to manually trigger an apply operation on Terraform layers that have a valid plan but autoApply is disabled.

### Changes

- Added `api.terraform.padok.cloud/apply-now` annotation to manually trigger applies
- Added `IsApplyScheduled` condition check in the controller to handle manual apply requests
- Modified `ApplyNeeded` state to distinguish between manual and automatic applies (manual applies bypass autoApply checks)
- Added new API endpoint `POST /layers/:namespace/:layer/apply` to trigger manual applies
- Updated UI with a "Play" icon button to trigger manual applies (shown only when autoApply is false and layer has a valid plan)
- Added tooltip logic to guide users when manual apply is not available
- Added unit tests for the manual apply flow
