### PR TITLE
chore(ci): fix documentation release with mike

### DIFF
--- a/.github/workflows/docs.yaml
+++ b/.github/workflows/docs.yaml
@@ -20,6 +20,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0  # Fetch all branches to include 'gh-pages' branch
       - uses: actions/setup-python@v5
         with:
           python-version: 3.x


### PR DESCRIPTION
- We do not need the command `set-default` at each release. latest is already updated with `mike deploy --update-aliases`
- The checkout needs to be done on all branches to include the "gh-pages" branch on which the docs is pushed