### PR TITLE
fix(docker): chown burrito user home directory

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -98,7 +98,7 @@ COPY --from=builder /workspace/bin/burrito /go/bin/dlv* /usr/local/bin/
 RUN mkdir -p /runner/bin
 RUN chmod +x /usr/local/bin/*
 # /home/burrito/.config is required for debug mode
-RUN mkdir -p /home/burrito/.config && chown -R burrito:burrito /runner /home/burrito/.config    
+RUN mkdir -p /home/burrito/.config && chown -R burrito:burrito /runner /home/burrito
 
 # Use an unprivileged user
 USER 65532:65532


### PR DESCRIPTION
Fixed Docker image permissions by ensuring the entire /home/burrito directory is owned by the burrito user

This solve an issue I've seen with the terraform helm provider when trying to write into `~/.cache`