### PR TITLE
chore: use upx to reduce

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -67,6 +67,14 @@ RUN --mount=type=cache,target=/root/.cache/go-build \
         -X ${PACKAGE}/internal/version.BuildTimestamp=${BUILD_TIMESTAMP}" \
         -o bin/burrito main.go
 
+FROM docker.io/library/alpine:3.21.3@sha256:a8560b36e8b8210634f77d9f7f9efd7ffa463e380b75e2e74aff4511df3ef88c as upx
+# Install UPX to compress the binary
+RUN apk add --no-cache upx
+# Compress the binary with UPX
+COPY --from=builder /workspace/bin/burrito /workspace/bin/burrito
+RUN upx --best --lzma /workspace/bin/burrito
+
+
 FROM docker.io/library/alpine:3.21.3@sha256:a8560b36e8b8210634f77d9f7f9efd7ffa463e380b75e2e74aff4511df3ef88c
 
 WORKDIR /home/burrito
@@ -93,7 +101,7 @@ RUN addgroup \
 
 # Copy the binary to the production image from the builder stage
 # Copy /go/bin/dlv*: the wildcard makes the copy to work, even if the binary is not present (in Release mode)
-COPY --from=builder /workspace/bin/burrito /go/bin/dlv* /usr/local/bin/
+COPY --from=upx /workspace/bin/burrito /go/bin/dlv* /usr/local/bin/
 
 RUN mkdir -p /runner/bin
 RUN chmod +x /usr/local/bin/*


### PR DESCRIPTION
This introduces another stage in our Dockerfile build that uses UPX to reduce the size of the burrito binary.

Preliminary tests suggest the image size ends up being around 40MB from 120MB.

I don't really know what to do with delve in that case @michael-todorovic 