### PR TITLE
fix: handle terragrunt 0.73.0+ new flags

### DIFF
--- a/internal/runner/tools/install.go
+++ b/internal/runner/tools/install.go
@@ -126,6 +126,7 @@ func InstallBinaries(layer *configv1alpha1.TerraformLayer, repo *configv1alpha1.
 		return &tg.Terragrunt{
 			ExecPath:      filepath.Join(binaryPath, "Terragrunt", terragruntVersion, "terragrunt"),
 			ChildExecPath: baseExec.GetExecPath(),
+			Version:       terragruntVersion,
 		}, nil
 	}
 	return baseExec, nil

--- a/internal/runner/tools/terragrunt/terragrunt.go
+++ b/internal/runner/tools/terragrunt/terragrunt.go
@@ -4,6 +4,7 @@ import (
 	"errors"
 	"os/exec"
 
+	"github.com/blang/semver/v4"
 	c "github.com/padok-team/burrito/internal/utils/cmd"
 )
 
@@ -11,6 +12,7 @@ type Terragrunt struct {
 	ExecPath      string
 	WorkingDir    string
 	ChildExecPath string
+	Version       string
 }
 
 func (t *Terragrunt) TenvName() string {
@@ -18,14 +20,46 @@ func (t *Terragrunt) TenvName() string {
 }
 
 func (t *Terragrunt) getDefaultOptions(command string) ([]string, error) {
-	return []string{
-		command,
-		"--terragrunt-tfpath",
-		t.ChildExecPath,
-		"--terragrunt-working-dir",
-		t.WorkingDir,
-		"-no-color",
-	}, nil
+	// Parse the version to determine which flags to use
+	// Terragrunt 0.73.0 introduced new shortened flags:
+	// - --terragrunt-tfpath -> --tf-path
+	// - --terragrunt-working-dir -> --working-dir
+	version, err := semver.Parse(t.Version)
+	if err != nil {
+		// If version parsing fails, use legacy flags as fallback
+		return []string{
+			command,
+			"--terragrunt-tfpath",
+			t.ChildExecPath,
+			"--terragrunt-working-dir",
+			t.WorkingDir,
+			"-no-color",
+		}, nil
+	}
+
+	newFlagsVersion := semver.MustParse("0.73.0")
+
+	if version.GTE(newFlagsVersion) {
+		// Use new flags for version 0.73.0 and above
+		return []string{
+			command,
+			"--tf-path",
+			t.ChildExecPath,
+			"--working-dir",
+			t.WorkingDir,
+			"-no-color",
+		}, nil
+	} else {
+		// Use legacy flags for versions below 0.73.0
+		return []string{
+			command,
+			"--terragrunt-tfpath",
+			t.ChildExecPath,
+			"--terragrunt-working-dir",
+			t.WorkingDir,
+			"-no-color",
+		}, nil
+	}
 }
 
 func (t *Terragrunt) Init(workingDir string) error {

--- a/internal/runner/tools/terragrunt/terragrunt_test.go
+++ b/internal/runner/tools/terragrunt/terragrunt_test.go
@@ -1,0 +1,211 @@
+package terragrunt
+
+import (
+	"reflect"
+	"testing"
+)
+
+func TestTerragrunt_getDefaultOptions(t *testing.T) {
+	tests := []struct {
+		name          string
+		version       string
+		command       string
+		workingDir    string
+		childExecPath string
+		expectedFlags []string
+		expectError   bool
+	}{
+		{
+			name:          "Legacy flags for version 0.66.9",
+			version:       "0.66.9",
+			command:       "plan",
+			workingDir:    "/path/to/working/dir",
+			childExecPath: "/path/to/terraform",
+			expectedFlags: []string{
+				"plan",
+				"--terragrunt-tfpath",
+				"/path/to/terraform",
+				"--terragrunt-working-dir",
+				"/path/to/working/dir",
+				"-no-color",
+			},
+			expectError: false,
+		},
+		{
+			name:          "Legacy flags for version 0.72.9",
+			version:       "0.72.9",
+			command:       "apply",
+			workingDir:    "/path/to/working/dir",
+			childExecPath: "/path/to/terraform",
+			expectedFlags: []string{
+				"apply",
+				"--terragrunt-tfpath",
+				"/path/to/terraform",
+				"--terragrunt-working-dir",
+				"/path/to/working/dir",
+				"-no-color",
+			},
+			expectError: false,
+		},
+		{
+			name:          "New flags for version 0.73.0",
+			version:       "0.73.0",
+			command:       "plan",
+			workingDir:    "/path/to/working/dir",
+			childExecPath: "/path/to/terraform",
+			expectedFlags: []string{
+				"plan",
+				"--tf-path",
+				"/path/to/terraform",
+				"--working-dir",
+				"/path/to/working/dir",
+				"-no-color",
+			},
+			expectError: false,
+		},
+		{
+			name:          "New flags for version 0.73.1",
+			version:       "0.73.1",
+			command:       "init",
+			workingDir:    "/path/to/working/dir",
+			childExecPath: "/path/to/terraform",
+			expectedFlags: []string{
+				"init",
+				"--tf-path",
+				"/path/to/terraform",
+				"--working-dir",
+				"/path/to/working/dir",
+				"-no-color",
+			},
+			expectError: false,
+		},
+		{
+			name:          "New flags for version 1.0.0",
+			version:       "1.0.0",
+			command:       "show",
+			workingDir:    "/path/to/working/dir",
+			childExecPath: "/path/to/terraform",
+			expectedFlags: []string{
+				"show",
+				"--tf-path",
+				"/path/to/terraform",
+				"--working-dir",
+				"/path/to/working/dir",
+				"-no-color",
+			},
+			expectError: false,
+		},
+		{
+			name:          "Invalid version fallback to legacy flags",
+			version:       "invalid-version",
+			command:       "plan",
+			workingDir:    "/path/to/working/dir",
+			childExecPath: "/path/to/terraform",
+			expectedFlags: []string{
+				"plan",
+				"--terragrunt-tfpath",
+				"/path/to/terraform",
+				"--terragrunt-working-dir",
+				"/path/to/working/dir",
+				"-no-color",
+			},
+			expectError: false,
+		},
+		{
+			name:          "Empty version fallback to legacy flags",
+			version:       "",
+			command:       "apply",
+			workingDir:    "/path/to/working/dir",
+			childExecPath: "/path/to/terraform",
+			expectedFlags: []string{
+				"apply",
+				"--terragrunt-tfpath",
+				"/path/to/terraform",
+				"--terragrunt-working-dir",
+				"/path/to/working/dir",
+				"-no-color",
+			},
+			expectError: false,
+		},
+		{
+			name:          "Pre-release version 0.73.0-rc1 uses legacy flags",
+			version:       "0.73.0-rc1",
+			command:       "plan",
+			workingDir:    "/path/to/working/dir",
+			childExecPath: "/path/to/terraform",
+			expectedFlags: []string{
+				"plan",
+				"--terragrunt-tfpath",
+				"/path/to/terraform",
+				"--terragrunt-working-dir",
+				"/path/to/working/dir",
+				"-no-color",
+			},
+			expectError: false,
+		},
+		{
+			name:          "Pre-release version 0.74.0-beta1 uses new flags",
+			version:       "0.74.0-beta1",
+			command:       "plan",
+			workingDir:    "/path/to/working/dir",
+			childExecPath: "/path/to/terraform",
+			expectedFlags: []string{
+				"plan",
+				"--tf-path",
+				"/path/to/terraform",
+				"--working-dir",
+				"/path/to/working/dir",
+				"-no-color",
+			},
+			expectError: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			tg := &Terragrunt{
+				ExecPath:      "/path/to/terragrunt",
+				WorkingDir:    tt.workingDir,
+				ChildExecPath: tt.childExecPath,
+				Version:       tt.version,
+			}
+
+			options, err := tg.getDefaultOptions(tt.command)
+
+			if tt.expectError && err == nil {
+				t.Errorf("Expected an error but got none")
+			}
+
+			if !tt.expectError && err != nil {
+				t.Errorf("Expected no error but got: %v", err)
+			}
+
+			if !reflect.DeepEqual(options, tt.expectedFlags) {
+				t.Errorf("Expected flags %v, but got %v", tt.expectedFlags, options)
+			}
+		})
+	}
+}
+
+func TestTerragrunt_TenvName(t *testing.T) {
+	tg := &Terragrunt{}
+	expected := "terragrunt"
+	result := tg.TenvName()
+
+	if result != expected {
+		t.Errorf("Expected TenvName to return %q, but got %q", expected, result)
+	}
+}
+
+func TestTerragrunt_GetExecPath(t *testing.T) {
+	expectedPath := "/path/to/terragrunt"
+	tg := &Terragrunt{
+		ExecPath: expectedPath,
+	}
+
+	result := tg.GetExecPath()
+
+	if result != expectedPath {
+		t.Errorf("Expected GetExecPath to return %q, but got %q", expectedPath, result)
+	}
+}


### PR DESCRIPTION
This PR fixes #661: it handles new terragrunt 0.73.0+ flags. Deprecated flags have been removed in 0.85.0