### PR TITLE
Revert "fix: move crds to allow helm --skip-crds usage"

### DIFF
--- a/deploy/charts/burrito/crds/crd-terraformlayers.yaml
+++ b/deploy/charts/burrito/crds/crd-terraformlayers.yaml
@@ -1,1 +1,0 @@
-../../../../manifests/crds/config.terraform.padok.cloud_terraformlayers.yaml

--- a/deploy/charts/burrito/crds/crd-terraformpullrequests.yaml
+++ b/deploy/charts/burrito/crds/crd-terraformpullrequests.yaml
@@ -1,1 +1,0 @@
-../../../../manifests/crds/config.terraform.padok.cloud_terraformpullrequests.yaml

--- a/deploy/charts/burrito/crds/crd-terraformrepositories.yaml
+++ b/deploy/charts/burrito/crds/crd-terraformrepositories.yaml
@@ -1,1 +1,0 @@
-../../../../manifests/crds/config.terraform.padok.cloud_terraformrepositories.yaml

--- a/deploy/charts/burrito/crds/crd-terraformruns.yaml
+++ b/deploy/charts/burrito/crds/crd-terraformruns.yaml
@@ -1,1 +1,0 @@
-../../../../manifests/crds/config.terraform.padok.cloud_terraformruns.yaml

--- a/deploy/charts/burrito/templates/crds/crd-terraformlayers.yaml
+++ b/deploy/charts/burrito/templates/crds/crd-terraformlayers.yaml
@@ -1,0 +1,1 @@
+../../../../../manifests/crds/config.terraform.padok.cloud_terraformlayers.yaml

--- a/deploy/charts/burrito/templates/crds/crd-terraformpullrequests.yaml
+++ b/deploy/charts/burrito/templates/crds/crd-terraformpullrequests.yaml
@@ -1,0 +1,1 @@
+../../../../../manifests/crds/config.terraform.padok.cloud_terraformpullrequests.yaml

--- a/deploy/charts/burrito/templates/crds/crd-terraformrepositories.yaml
+++ b/deploy/charts/burrito/templates/crds/crd-terraformrepositories.yaml
@@ -1,0 +1,1 @@
+../../../../../manifests/crds/config.terraform.padok.cloud_terraformrepositories.yaml

--- a/deploy/charts/burrito/templates/crds/crd-terraformruns.yaml
+++ b/deploy/charts/burrito/templates/crds/crd-terraformruns.yaml
@@ -1,0 +1,1 @@
+../../../../../manifests/crds/config.terraform.padok.cloud_terraformruns.yaml

--- a/deploy/charts/burrito/values.yaml
+++ b/deploy/charts/burrito/values.yaml
@@ -1,3 +1,8 @@
+# TODO: Make CRD install optional? or use --skip-crds Helm flag
+# Custom Resource Definitions
+# crds:
+# install: true
+
 # Burrito configuration
 ## Ref: https://docs.burrito.tf/operator-manual/advanced-configuration/
 config:


### PR DESCRIPTION
Reverts padok-team/burrito#663

Actually this PR was a breaking change that removes the CRDs on existing Burrito installations. For now we gonna keep the existing process.

WDYT @michael-todorovic is there a smooth way that can permit to not install CRD when needed but does not impact existing Burrito installations ?

[See Helm docs](https://helm.sh/docs/chart_best_practices/custom_resource_definitions/)