### PR TITLE
feat: allow control of k8s rbac installation

### DIFF
--- a/deploy/charts/burrito/templates/rbac-controllers.yaml
+++ b/deploy/charts/burrito/templates/rbac-controllers.yaml
@@ -1,3 +1,4 @@
+{{- if .Values.rbac.install }}
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
@@ -162,3 +163,4 @@ rules:
   - update
   - patch
   - delete
+{{- end }}

--- a/deploy/charts/burrito/templates/rbac-runner.yaml
+++ b/deploy/charts/burrito/templates/rbac-runner.yaml
@@ -1,3 +1,4 @@
+{{- if .Values.rbac.install }}
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
@@ -33,3 +34,4 @@ rules:
   - terraformrepositories
   verbs:
   - get
+{{- end }}

--- a/deploy/charts/burrito/templates/rbac-server.yaml
+++ b/deploy/charts/burrito/templates/rbac-server.yaml
@@ -1,3 +1,4 @@
+{{- if .Values.rbac.install }}
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
@@ -99,3 +100,4 @@ rules:
   - update
   - watch
   - get
+{{- end }}

--- a/deploy/charts/burrito/values.yaml
+++ b/deploy/charts/burrito/values.yaml
@@ -268,6 +268,9 @@ global:
     extraVolumes: {}
     # -- Additional volume mounts
     extraVolumeMounts: {}
+  # -- Global RBAC configuration
+  rbac:
+    install: true # Enable RBAC installation
   # -- Global service configuration
   service:
     # -- Enable/Disable service creation for Burrito components


### PR DESCRIPTION
This PR is a companion of #688 to prepare Burrito multi-instances setup. It allows to choose to install k8s rbac or not. By default, it keeps the current behavior and installs them