### PR TITLE
feat(helm): add NetworkPolicy template to allow traffic from tenants

### DIFF
--- a/deploy/charts/burrito/templates/networkpolicy.yaml
+++ b/deploy/charts/burrito/templates/networkpolicy.yaml
@@ -1,0 +1,40 @@
+{{- if .Values.networkPolicy.enabled }}
+{{- if and .Values.networkPolicy.ingressFromTenants.enabled (gt (len .Values.tenants) 0) }}
+---
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: allow-traffic-from-burrito-tenants
+  labels:
+    {{- with .Values.global.metadata.labels }}
+    {{- toYaml . | nindent 4 }}
+    {{- end }}
+    {{- with .Values.networkPolicy.metadata.labels }}
+    {{- toYaml . | nindent 4 }}
+    {{- end }}
+  annotations:
+    {{- with .Values.global.metadata.annotations }}
+    {{- toYaml . | nindent 4 }}
+    {{- end }}
+    {{- with .Values.networkPolicy.metadata.annotations }}
+    {{- toYaml . | nindent 4 }}
+    {{- end }}
+spec:
+  podSelector: {}
+  policyTypes:
+    - Ingress
+  ingress:
+    # Allow all traffic from tenant namespaces
+    {{- range .Values.tenants }}
+    {{- if .namespace.create }}
+    - from:
+        - namespaceSelector:
+            matchLabels:
+              kubernetes.io/metadata.name: {{ .namespace.name }}
+    {{- end }}
+    {{- end }}
+    {{- with .Values.networkPolicy.ingressFromTenants.additionalIngressRules }}
+    {{- toYaml . | nindent 4 }}
+    {{- end }}
+{{- end }}
+{{- end }}

--- a/deploy/charts/burrito/values.yaml
+++ b/deploy/charts/burrito/values.yaml
@@ -103,7 +103,7 @@ config:
         repository: ghcr.io/padok-team/burrito
         tag: "" # By default use Chart's appVersion
         pullPolicy: Always
-      
+
       # -- Command to run in the Burrito runner container
       command: ["burrito"]
       # -- Arguments to pass to the Burrito runner container
@@ -485,3 +485,18 @@ tenants: []
 #       annotations:
 #         iam.cloud.provider/role: cloud-provider-role
 #       labels: {}
+
+# Network Policy configuration
+networkPolicy:
+  # -- Enable/Disable Network Policy creation
+  enabled: false
+  # -- Metadata configuration for Network Policies
+  metadata:
+    labels: {}
+    annotations: {}
+  # -- Network policy to allow ingress traffic from all the tenant namespaces to the release namespace
+  ingressFromTenants:
+    # -- Enable/Disable tenant ingress network policy
+    enabled: true
+    # -- Additional ingress rules for tenant namespaces network policy
+    additionalIngressRules: []


### PR DESCRIPTION
Disabled by default for backward compatibility