### PR TITLE
fix(chart): annotations/labels on tenants service accounts

### DIFF
--- a/deploy/charts/burrito/templates/tenant.yaml
+++ b/deploy/charts/burrito/templates/tenant.yaml
@@ -126,7 +126,7 @@ kind: ServiceAccount
 metadata:
   name: {{ $serviceAccount.name }}
   namespace: {{ $tenant.namespace.name }}
-  {{- with $metadataServiceAccount.metadata }}
+  {{- with $metadataServiceAccount }}
   labels:
     {{- toYaml .labels | nindent 4}}
   annotations:
@@ -159,7 +159,7 @@ kind: RoleBinding
 metadata:
   name: {{ $additionalRoleBinding.name }}
   namespace: {{ $tenant.namespace.name }}
-  {{- with $metadataServiceAccount.metadata }}
+  {{- with $metadataServiceAccount }}
   labels:
     {{- toYaml .labels | nindent 4}}
   annotations:


### PR DESCRIPTION
#711 changed how metadata are passed to tenants' service accounts, the values were broken because the templates was reading `serviceAccount.metadata.metadata`