### PR TITLE
fix(helm): clean up duplicate metadata blocks

### DIFF
--- a/deploy/charts/burrito/templates/tenant.yaml
+++ b/deploy/charts/burrito/templates/tenant.yaml
@@ -86,10 +86,6 @@ metadata:
   annotations:
     {{- toYaml .annotations | nindent 4}}
   {{- end }}
-  labels:
-    {{- toYaml $metadataControllers.labels | nindent 4 }}
-  annotations:
-    {{- toYaml $metadataControllers.annotations | nindent 4 }}
 rules:
   - apiGroups: [""]
     resources: ["secrets"]
@@ -106,10 +102,6 @@ metadata:
   annotations:
     {{- toYaml .annotations | nindent 4}}
   {{- end }}
-  labels:
-    {{- toYaml $metadataControllers.labels | nindent 4 }}
-  annotations:
-    {{- toYaml $metadataControllers.annotations | nindent 4 }}
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: Role


### PR DESCRIPTION
Fixes #786 

This PR removes duplicate `metadata.labels` and `metadata.annotations` templates, favoring the new `{{- with }}` blocks added in #711. The invalid YAML created by these duplicate keys is unparseable by Helm "wrappers" such as `kustomize build --enable-helm`.