### PR TITLE
fix(chart): duplicated metadata blocks on tenants RBAC

### DIFF
--- a/deploy/charts/burrito/templates/tenant.yaml
+++ b/deploy/charts/burrito/templates/tenant.yaml
@@ -80,7 +80,7 @@ kind: Role
 metadata:
   name: secret-access
   namespace: {{ $tenant.namespace.name }}
-  {{- with mergeOverwrite (deepCopy $metadataTenant) $metadataControllers }}
+  {{- with mergeOverwrite (deepCopy $metadataTenant) $metadataServer }}
   labels:
     {{- toYaml .labels | nindent 4}}
   annotations:
@@ -96,7 +96,7 @@ kind: RoleBinding
 metadata:
   name: burrito-server-secret-access
   namespace: {{ $tenant.namespace.name }}
-  {{- with mergeOverwrite (deepCopy $metadataTenant) $metadataControllers }}
+  {{- with mergeOverwrite (deepCopy $metadataTenant) $metadataServer }}
   labels:
     {{- toYaml .labels | nindent 4}}
   annotations:


### PR DESCRIPTION
Hi!

Here's a fix for an Helm chart bug introduced with metadata rework on https://github.com/padok-team/burrito/pull/711.

For tenant's role+binding there is duplicated labels/annotations.

Is it possible to have a quick release with this fix?