### PR TITLE
fix: "standard" is not caught as correct provider

### DIFF
--- a/internal/repository/repository.go
+++ b/internal/repository/repository.go
@@ -45,7 +45,7 @@ func GetProviderFromCredentials(RepositoryCredentials credentials.Credential) (t
 		return &github.Github{Config: RepositoryCredentials}, nil
 	case "gitlab":
 		return &gitlab.Gitlab{Config: RepositoryCredentials}, nil
-	case "git":
+	case "standard":
 		return &standard.Standard{Config: RepositoryCredentials}, nil
 	case "mock":
 		return &mock.Mock{}, nil


### PR DESCRIPTION
Hello,

I tested your project and I had a weird error with my git configuration (I am using a self hosted instance of Gitea)

```
Failed to get git provider: unknown provider: standard
```

I was really suprised so I read[ the doc again and again](https://docs.burrito.tf/latest/operator-manual/git-authentication/#repository-specific-credential-using-usernamepassword-standard-git-authentication), it says the `standard` provider is possible.

I finally went to the code and caught this switch case where the expected provider value is `git`, not `standard`. According to the fact that document says `standard` everywhere and the code calls it `standard` too, I guess the correct thing to do here is to rename `git`.

It works when I set `provider: git` in the `TerraformRepository` spec :)

Thank your for your work!