### PR TITLE
build: use mise to install devtools

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -27,6 +27,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v6
+      - name: Setup mise
+        uses: jdx/mise-action@v3
       - name: Cache envtest binaries
         uses: actions/cache@v5
         with:
@@ -36,10 +38,8 @@ jobs:
         uses: actions/setup-go@v6
         with:
           go-version-file: "go.mod"
-      - name: Install envtest
-        run: make envtest
       - name: Setup envtest
-        run: ./bin/setup-envtest use
+        run: setup-envtest use
       - name: Set up Docker Buildx for docker compose
         uses: docker/setup-buildx-action@v3
       - name: Run tests
@@ -55,6 +55,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v6
+      - name: Setup mise
+        uses: jdx/mise-action@v2
       - name: Setup Golang
         uses: actions/setup-go@v6
         with:

--- a/mise.toml
+++ b/mise.toml
@@ -1,0 +1,11 @@
+[tool_alias]
+controller-gen = 'github:kubernetes-sigs/controller-tools'
+setup-envtest = 'github:kubernetes-sigs/controller-runtime'
+
+[tools]
+controller-gen = "0.20.0"
+helm = "4.1.1"
+kind = "0.31.0"
+kubectl = "1.35.1"
+kustomize = "5.7.1"
+setup-envtest = "0.23.1"


### PR DESCRIPTION
Hi team,

I've noticed last time I worked on an old copy of the repo that the binaries cached in `./bin` were outdated and thus the manifest generation was creating a local drift. I figured that we could improve the DevEx by using a more robust version manager. 

This PR migrates the project's development tools management to [mise](https://mise.jdx.dev/)

Let me know if you find this useful
