### PR TITLE
fix: missing filter TerraformRepository by namespace

### DIFF
--- a/internal/controllers/terraformrepository/controller_test.go
+++ b/internal/controllers/terraformrepository/controller_test.go
@@ -838,6 +838,98 @@ var _ = Describe("Run", func() {
 			})
 		})
 	})
+	Describe("Namespace Isolation", func() {
+		Describe("When two repositories have the same name in different namespaces", Ordered, func() {
+			BeforeAll(func() {
+				// Reconcile repo in namespace-a
+				name = types.NamespacedName{
+					Name:      "provisioning",
+					Namespace: "namespace-a",
+				}
+				result, repo, reconcileError, err = getResult(name)
+			})
+			It("should not return an error", func() {
+				Expect(reconcileError).NotTo(HaveOccurred())
+			})
+			It("should annotate the layer in namespace-a", func() {
+				layer := &configv1alpha1.TerraformLayer{}
+				Expect(k8sClient.Get(context.TODO(), types.NamespacedName{
+					Name:      "layer-ns-a",
+					Namespace: "namespace-a",
+				}, layer)).To(Succeed())
+				Expect(layer.Annotations).To(HaveKeyWithValue(annotations.LastBranchCommit, mock.GetMockRevision("main")))
+			})
+			It("should NOT annotate the layer in namespace-b", func() {
+				layer := &configv1alpha1.TerraformLayer{}
+				Expect(k8sClient.Get(context.TODO(), types.NamespacedName{
+					Name:      "layer-ns-b",
+					Namespace: "namespace-b",
+				}, layer)).To(Succeed())
+				_, hasBranchCommit := layer.Annotations[annotations.LastBranchCommit]
+				Expect(hasBranchCommit).To(BeFalse(), "layer in namespace-b should not be annotated by repo in namespace-a")
+			})
+			It("should only store the bundle for namespace-a", func() {
+				check, err := reconciler.Datastore.CheckGitBundle("namespace-a", "provisioning", "main", mock.GetMockRevision("main"))
+				Expect(err).NotTo(HaveOccurred())
+				Expect(check).To(BeTrue(), "bundle should exist for namespace-a")
+
+				check, err = reconciler.Datastore.CheckGitBundle("namespace-b", "provisioning", "main", mock.GetMockRevision("main"))
+				Expect(err).NotTo(HaveOccurred())
+				Expect(check).To(BeFalse(), "bundle should NOT exist for namespace-b yet")
+			})
+			It("should be able to retrieve the bundle for namespace-a", func() {
+				bundle, err := reconciler.Datastore.GetGitBundle("namespace-a", "provisioning", "main", mock.GetMockRevision("main"))
+				Expect(err).NotTo(HaveOccurred())
+				Expect(string(bundle)).To(Equal("bundle:namespace-a/provisioning/main"))
+			})
+			It("should NOT be able to retrieve a bundle for namespace-b", func() {
+				_, err := reconciler.Datastore.GetGitBundle("namespace-b", "provisioning", "main", mock.GetMockRevision("main"))
+				Expect(err).To(HaveOccurred())
+			})
+		})
+		Describe("When reconciling the second repository in namespace-b", Ordered, func() {
+			BeforeAll(func() {
+				name = types.NamespacedName{
+					Name:      "provisioning",
+					Namespace: "namespace-b",
+				}
+				result, repo, reconcileError, err = getResult(name)
+			})
+			It("should not return an error", func() {
+				Expect(reconcileError).NotTo(HaveOccurred())
+			})
+			It("should annotate the layer in namespace-b", func() {
+				layer := &configv1alpha1.TerraformLayer{}
+				Expect(k8sClient.Get(context.TODO(), types.NamespacedName{
+					Name:      "layer-ns-b",
+					Namespace: "namespace-b",
+				}, layer)).To(Succeed())
+				Expect(layer.Annotations).To(HaveKeyWithValue(annotations.LastBranchCommit, mock.GetMockRevision("main")))
+			})
+			It("should now have bundles for both namespaces", func() {
+				checkA, err := reconciler.Datastore.CheckGitBundle("namespace-a", "provisioning", "main", mock.GetMockRevision("main"))
+				Expect(err).NotTo(HaveOccurred())
+				Expect(checkA).To(BeTrue())
+
+				checkB, err := reconciler.Datastore.CheckGitBundle("namespace-b", "provisioning", "main", mock.GetMockRevision("main"))
+				Expect(err).NotTo(HaveOccurred())
+				Expect(checkB).To(BeTrue())
+			})
+			It("should be able to retrieve bundles for both namespaces independently", func() {
+				bundleA, err := reconciler.Datastore.GetGitBundle("namespace-a", "provisioning", "main", mock.GetMockRevision("main"))
+				Expect(err).NotTo(HaveOccurred())
+				Expect(string(bundleA)).To(Equal("bundle:namespace-a/provisioning/main"))
+
+				bundleB, err := reconciler.Datastore.GetGitBundle("namespace-b", "provisioning", "main", mock.GetMockRevision("main"))
+				Expect(err).NotTo(HaveOccurred())
+				Expect(string(bundleB)).To(Equal("bundle:namespace-b/provisioning/main"))
+			})
+			It("should not return a bundle for a non-existent namespace", func() {
+				_, err := reconciler.Datastore.GetGitBundle("namespace-c", "provisioning", "main", mock.GetMockRevision("main"))
+				Expect(err).To(HaveOccurred())
+			})
+		})
+	})
 })
 
 var _ = AfterSuite(func() {

--- a/internal/controllers/terraformrepository/polling.go
+++ b/internal/controllers/terraformrepository/polling.go
@@ -9,14 +9,14 @@ import (
 
 // Returns the list of layers that are managed by this repository
 func (r *Reconciler) retrieveManagedLayers(ctx context.Context, repository *configv1alpha1.TerraformRepository) ([]configv1alpha1.TerraformLayer, error) {
-	// get all layers that depends on the repository (layer.spec.repository.name == repository.name)
+	// get all layers that depends on the repository (layer.spec.repository.name == repository.name && layer.spec.repository.namespace == repository.namespace)
 	layers := &configv1alpha1.TerraformLayerList{}
 	if err := r.List(ctx, layers); err != nil {
 		return nil, err
 	}
 	managedLayers := []configv1alpha1.TerraformLayer{}
 	for _, layer := range layers.Items {
-		if layer.Spec.Repository.Name == repository.Name {
+		if layer.Spec.Repository.Name == repository.Name && layer.Spec.Repository.Namespace == repository.Namespace {
 			managedLayers = append(managedLayers, layer)
 		}
 	}

--- a/internal/controllers/terraformrepository/testdata/credentials.yaml
+++ b/internal/controllers/terraformrepository/testdata/credentials.yaml
@@ -8,3 +8,23 @@ type: credentials.burrito.tf/repository
 stringData:
   provider: mock
   url: https://github.com/padok-team/burrito-examples
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  name: burrito-repo
+  namespace: namespace-a
+type: credentials.burrito.tf/repository
+stringData:
+  provider: mock
+  url: https://github.com/padok-team/burrito-examples
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  name: burrito-repo
+  namespace: namespace-b
+type: credentials.burrito.tf/repository
+stringData:
+  provider: mock
+  url: https://github.com/padok-team/burrito-examples

--- a/internal/controllers/terraformrepository/testdata/nominal-case.yaml
+++ b/internal/controllers/terraformrepository/testdata/nominal-case.yaml
@@ -310,3 +310,62 @@ spec:
   repository:
     name: repo-sync-now-old
     namespace: default
+---
+# Two repositories with the same name "provisioning" in different namespaces
+# Each has a layer that should only be managed by its own namespace's repo
+---
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: namespace-a
+---
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: namespace-b
+---
+apiVersion: config.terraform.padok.cloud/v1alpha1
+kind: TerraformRepository
+metadata:
+  name: provisioning
+  namespace: namespace-a
+spec:
+  repository:
+    url: https://github.com/padok-team/burrito-examples
+  terraform:
+    enabled: true
+---
+apiVersion: config.terraform.padok.cloud/v1alpha1
+kind: TerraformRepository
+metadata:
+  name: provisioning
+  namespace: namespace-b
+spec:
+  repository:
+    url: https://github.com/padok-team/burrito-examples
+  terraform:
+    enabled: true
+---
+apiVersion: config.terraform.padok.cloud/v1alpha1
+kind: TerraformLayer
+metadata:
+  name: layer-ns-a
+  namespace: namespace-a
+spec:
+  branch: main
+  path: layer/
+  repository:
+    name: provisioning
+    namespace: namespace-a
+---
+apiVersion: config.terraform.padok.cloud/v1alpha1
+kind: TerraformLayer
+metadata:
+  name: layer-ns-b
+  namespace: namespace-b
+spec:
+  branch: main
+  path: layer/
+  repository:
+    name: provisioning
+    namespace: namespace-b

--- a/internal/controllers/terraformrun/controller.go
+++ b/internal/controllers/terraformrun/controller.go
@@ -113,7 +113,7 @@ func (r *Reconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Resu
 	}
 	if !bundleOk {
 		r.Recorder.Event(run, corev1.EventTypeWarning, "Reconciliation", fmt.Sprintf("Bundle for revision %s not found in datastore", run.Spec.Layer.Revision))
-		log.Errorf("bundle for revision %s not found in datastore", run.Spec.Layer.Revision)
+		log.Errorf("bundle for revision %s not found in datastore, failing run %s/%s", run.Spec.Layer.Revision, run.Namespace, run.Name)
 		return ctrl.Result{RequeueAfter: r.Config.Controller.Timers.OnError}, nil
 	}
 

--- a/internal/repository/providers/mock/mock.go
+++ b/internal/repository/providers/mock/mock.go
@@ -40,7 +40,9 @@ func (p *GitProvider) Bundle(ref string) ([]byte, error) {
 	if p.testfail() {
 		return nil, errors.New("mock provider: clone failed")
 	}
-	return make([]byte, 1), nil
+	// Return a unique bundle per namespace/repo/ref so tests can verify isolation
+	content := fmt.Sprintf("bundle:%s/%s/%s", p.repository.Namespace, p.repository.Name, ref)
+	return []byte(content), nil
 }
 
 func (p *GitProvider) GetChanges(previousCommit, currentCommit string) []string {


### PR DESCRIPTION
This PR fixes #756: when you have several repositories named the same on different namespaces, Burrito was grabbing the wrong git bundle due to lack of namespace filtering. This was leading to wrong statuses in the managed layers

I added a bunch of tests to cover this case