### PR TITLE
Add controller fields to reconciler logs

### DIFF
--- a/internal/controllers/terraformlayer/conditions.go
+++ b/internal/controllers/terraformlayer/conditions.go
@@ -10,7 +10,6 @@ import (
 	configv1alpha1 "github.com/padok-team/burrito/api/v1alpha1"
 	"github.com/padok-team/burrito/internal/annotations"
 	terraformrun "github.com/padok-team/burrito/internal/controllers/terraformrun"
-	log "github.com/sirupsen/logrus"
 	"k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"

--- a/internal/controllers/terraformlayer/controller.go
+++ b/internal/controllers/terraformlayer/controller.go
@@ -38,8 +38,6 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/event"
 	"sigs.k8s.io/controller-runtime/pkg/predicate"
 
-	log "github.com/sirupsen/logrus"
-
 	configv1alpha1 "github.com/padok-team/burrito/api/v1alpha1"
 )
 

--- a/internal/controllers/terraformlayer/logger.go
+++ b/internal/controllers/terraformlayer/logger.go
@@ -1,0 +1,5 @@
+package terraformlayer
+
+import "github.com/sirupsen/logrus"
+
+var log = logrus.WithField("controller", "TerraformLayer")

--- a/internal/controllers/terraformlayer/states.go
+++ b/internal/controllers/terraformlayer/states.go
@@ -8,7 +8,6 @@ import (
 	configv1alpha1 "github.com/padok-team/burrito/api/v1alpha1"
 	"github.com/padok-team/burrito/internal/annotations"
 	"github.com/padok-team/burrito/internal/utils/syncwindow"
-	log "github.com/sirupsen/logrus"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	ctrl "sigs.k8s.io/controller-runtime"

--- a/internal/controllers/terraformpullrequest/controller.go
+++ b/internal/controllers/terraformpullrequest/controller.go
@@ -18,8 +18,6 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/event"
 	"sigs.k8s.io/controller-runtime/pkg/predicate"
 
-	log "github.com/sirupsen/logrus"
-
 	configv1alpha1 "github.com/padok-team/burrito/api/v1alpha1"
 )
 

--- a/internal/controllers/terraformpullrequest/layer.go
+++ b/internal/controllers/terraformpullrequest/layer.go
@@ -15,7 +15,6 @@ import (
 	"github.com/padok-team/burrito/internal/annotations"
 	controller "github.com/padok-team/burrito/internal/controllers/terraformlayer"
 	repo "github.com/padok-team/burrito/internal/repository"
-	log "github.com/sirupsen/logrus"
 )
 
 func (r *Reconciler) getAffectedLayers(repository *configv1alpha1.TerraformRepository, pr *configv1alpha1.TerraformPullRequest) ([]configv1alpha1.TerraformLayer, error) {

--- a/internal/controllers/terraformpullrequest/logger.go
+++ b/internal/controllers/terraformpullrequest/logger.go
@@ -1,0 +1,5 @@
+package terraformpullrequest
+
+import "github.com/sirupsen/logrus"
+
+var log = logrus.WithField("controller", "TerraformPullRequest")

--- a/internal/controllers/terraformpullrequest/states.go
+++ b/internal/controllers/terraformpullrequest/states.go
@@ -8,7 +8,6 @@ import (
 	"github.com/padok-team/burrito/internal/annotations"
 	"github.com/padok-team/burrito/internal/controllers/terraformpullrequest/comment"
 	repo "github.com/padok-team/burrito/internal/repository"
-	log "github.com/sirupsen/logrus"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	ctrl "sigs.k8s.io/controller-runtime"

--- a/internal/controllers/terraformrepository/controller.go
+++ b/internal/controllers/terraformrepository/controller.go
@@ -22,7 +22,6 @@ import (
 
 	"github.com/google/go-cmp/cmp"
 	"github.com/padok-team/burrito/internal/controllers/metrics"
-	log "github.com/sirupsen/logrus"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/runtime"

--- a/internal/controllers/terraformrepository/logger.go
+++ b/internal/controllers/terraformrepository/logger.go
@@ -1,0 +1,5 @@
+package terraformrepository
+
+import "github.com/sirupsen/logrus"
+
+var log = logrus.WithField("controller", "TerraformRepository")

--- a/internal/controllers/terraformrepository/states.go
+++ b/internal/controllers/terraformrepository/states.go
@@ -11,7 +11,6 @@ import (
 	layerCtrl "github.com/padok-team/burrito/internal/controllers/terraformlayer"
 	repo "github.com/padok-team/burrito/internal/repository"
 	"github.com/padok-team/burrito/internal/repository/types"
-	log "github.com/sirupsen/logrus"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	ctrl "sigs.k8s.io/controller-runtime"

--- a/internal/controllers/terraformrun/conditions.go
+++ b/internal/controllers/terraformrun/conditions.go
@@ -6,7 +6,6 @@ import (
 	"time"
 
 	configv1alpha1 "github.com/padok-team/burrito/api/v1alpha1"
-	log "github.com/sirupsen/logrus"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"

--- a/internal/controllers/terraformrun/controller.go
+++ b/internal/controllers/terraformrun/controller.go
@@ -30,7 +30,6 @@ import (
 	datastore "github.com/padok-team/burrito/internal/datastore/client"
 	logClient "k8s.io/client-go/kubernetes"
 
-	log "github.com/sirupsen/logrus"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/runtime"

--- a/internal/controllers/terraformrun/logger.go
+++ b/internal/controllers/terraformrun/logger.go
@@ -1,0 +1,5 @@
+package terraformrun
+
+import "github.com/sirupsen/logrus"
+
+var log = logrus.WithField("controller", "TerraformRun")

--- a/internal/controllers/terraformrun/pod.go
+++ b/internal/controllers/terraformrun/pod.go
@@ -7,7 +7,6 @@ import (
 
 	configv1alpha1 "github.com/padok-team/burrito/api/v1alpha1"
 	"github.com/padok-team/burrito/internal/burrito/config"
-	log "github.com/sirupsen/logrus"
 	corev1 "k8s.io/api/core/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"

--- a/internal/controllers/terraformrun/states.go
+++ b/internal/controllers/terraformrun/states.go
@@ -9,7 +9,6 @@ import (
 	configv1alpha1 "github.com/padok-team/burrito/api/v1alpha1"
 	"github.com/padok-team/burrito/internal/controllers/metrics"
 	"github.com/padok-team/burrito/internal/lock"
-	log "github.com/sirupsen/logrus"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/labels"


### PR DESCRIPTION
Fixes #415.

## Summary
- Add controller-specific logrus entries for TerraformLayer, TerraformRepository, TerraformPullRequest, and TerraformRun reconcilers
- Reuse the package logger in existing controller log calls so log output includes a `controller` field

## Verification
- `go test ./internal/controllers/terraformlayer ./internal/controllers/terraformrepository ./internal/controllers/terraformpullrequest ./internal/controllers/terraformrun -run '^$'`\n\nNote: the full envtest-backed controller suites require local kubebuilder assets (`/usr/local/kubebuilder/bin/etcd`) and could not run in this environment.