### PR TITLE
fix: include layer run creation errors in events

### DIFF
--- a/internal/controllers/terraformlayer/states.go
+++ b/internal/controllers/terraformlayer/states.go
@@ -80,7 +80,7 @@ func (s *PlanNeeded) getHandler() Handler {
 		run := r.getRun(layer, revision, PlanAction)
 		err := r.Client.Create(ctx, &run)
 		if err != nil {
-			r.Recorder.Event(layer, corev1.EventTypeWarning, "Reconciliation", "Failed to create TerraformRun for Plan action")
+			r.Recorder.Eventf(layer, corev1.EventTypeWarning, "Reconciliation", "Failed to create TerraformRun for Plan action: %s", err)
 			log.Errorf("failed to create TerraformRun for Plan action on layer %s: %s", layer.Name, err)
 			return ctrl.Result{RequeueAfter: r.Config.Controller.Timers.OnError}, nil
 		}
@@ -112,7 +112,7 @@ func (s *ApplyNeeded) getHandler() Handler {
 		run := r.getRun(layer, revision, ApplyAction)
 		err := r.Client.Create(ctx, &run)
 		if err != nil {
-			r.Recorder.Event(layer, corev1.EventTypeWarning, "Reconciliation", "Failed to create TerraformRun for Apply action")
+			r.Recorder.Eventf(layer, corev1.EventTypeWarning, "Reconciliation", "Failed to create TerraformRun for Apply action: %s", err)
 			log.Errorf("failed to create TerraformRun for Apply action on layer %s: %s", layer.Name, err)
 			return ctrl.Result{RequeueAfter: r.Config.Controller.Timers.OnError}, nil
 		}

--- a/internal/controllers/terraformlayer/states_test.go
+++ b/internal/controllers/terraformlayer/states_test.go
@@ -1,0 +1,104 @@
+package terraformlayer
+
+import (
+	"context"
+	"errors"
+	"strings"
+	"testing"
+
+	configv1alpha1 "github.com/padok-team/burrito/api/v1alpha1"
+	"github.com/padok-team/burrito/internal/annotations"
+	"github.com/padok-team/burrito/internal/burrito/config"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/tools/record"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+type createErrorClient struct {
+	client.Client
+	err error
+}
+
+func (c createErrorClient) Create(context.Context, client.Object, ...client.CreateOption) error {
+	return c.err
+}
+
+func TestPlanNeededEventIncludesCreateError(t *testing.T) {
+	createErr := errors.New("metadata.labels: Invalid value: must be no more than 63 characters")
+	recorder := record.NewFakeRecorder(1)
+	reconciler := &Reconciler{
+		Client:   createErrorClient{err: createErr},
+		Recorder: recorder,
+		Config:   config.TestConfig(),
+	}
+	layer := &configv1alpha1.TerraformLayer{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "infra-s3-buckets-logistics-toolings-dc1-nl-prd-defect-tracker-prd-nl1",
+			Namespace: "default",
+			Annotations: map[string]string{
+				annotations.LastRelevantCommit: "abc123",
+			},
+		},
+	}
+
+	result, run := (&PlanNeeded{}).getHandler()(context.Background(), reconciler, layer, &configv1alpha1.TerraformRepository{})
+
+	if run != nil {
+		t.Fatalf("expected no run when creation fails")
+	}
+	if result.RequeueAfter != reconciler.Config.Controller.Timers.OnError {
+		t.Fatalf("expected OnError requeue, got %s", result.RequeueAfter)
+	}
+	assertEventContains(t, recorder, "Failed to create TerraformRun for Plan action: "+createErr.Error())
+}
+
+func TestApplyNeededEventIncludesCreateError(t *testing.T) {
+	createErr := errors.New("metadata.labels: Invalid value: must be no more than 63 characters")
+	recorder := record.NewFakeRecorder(1)
+	reconciler := &Reconciler{
+		Client:   createErrorClient{err: createErr},
+		Recorder: recorder,
+		Config:   config.TestConfig(),
+	}
+	autoApply := true
+	layer := &configv1alpha1.TerraformLayer{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "infra-s3-buckets-logistics-toolings-dc1-nl-prd-defect-tracker-prd-nl1",
+			Namespace: "default",
+			Annotations: map[string]string{
+				annotations.LastRelevantCommit: "abc123",
+				annotations.LastPlanRun:        "plan-run/0",
+			},
+		},
+	}
+	repository := &configv1alpha1.TerraformRepository{
+		Spec: configv1alpha1.TerraformRepositorySpec{
+			RemediationStrategy: configv1alpha1.RemediationStrategy{
+				AutoApply: &autoApply,
+			},
+		},
+	}
+
+	result, run := (&ApplyNeeded{}).getHandler()(context.Background(), reconciler, layer, repository)
+
+	if run != nil {
+		t.Fatalf("expected no run when creation fails")
+	}
+	if result.RequeueAfter != reconciler.Config.Controller.Timers.OnError {
+		t.Fatalf("expected OnError requeue, got %s", result.RequeueAfter)
+	}
+	assertEventContains(t, recorder, "Failed to create TerraformRun for Apply action: "+createErr.Error())
+}
+
+func assertEventContains(t *testing.T, recorder *record.FakeRecorder, want string) {
+	t.Helper()
+
+	select {
+	case event := <-recorder.Events:
+		if !strings.Contains(event, want) {
+			t.Fatalf("expected event to contain %q, got %q", want, event)
+		}
+	default:
+		t.Fatalf("expected event containing %q, got none", want)
+	}
+}


### PR DESCRIPTION
Fixes #601.

## Summary
- include the underlying TerraformRun creation error in TerraformLayer warning events for plan/apply failures
- add focused tests for PlanNeeded and ApplyNeeded create failures so the emitted events include the error text

## Validation
- `gofmt -l internal/controllers/terraformlayer/states.go internal/controllers/terraformlayer/states_test.go` (no output)
- `git diff origin/main..HEAD --check`
- `git diff origin/main..HEAD | gitleaks stdin --no-banner --redact --exit-code 1` (`no leaks found`)
- duplicate PR check for `#601`, event text, and `metadata.labels` terms returned no equivalent open PR

Not completed locally: `go test ./internal/controllers/terraformlayer -run 'Test(PlanNeededEventIncludesCreateError|ApplyNeededEventIncludesCreateError)'`. On this Mac, the TerraformLayer test binary repeatedly stalled in the Go linker during default, `-buildmode=exe`, `CGO_ENABLED=0 -linkmode=internal`, and Linux compile-only attempts. No test assertion failure was produced before stopping those local linker stalls.