### PR TITLE
docs: explain private Terraform provider registry setup

### DIFF
--- a/docs/user-guide/private-modules.md
+++ b/docs/user-guide/private-modules.md
@@ -143,3 +143,70 @@ In this case, we added a new volume and a new environment variable to the runner
 
 - The volume is a secret volume that contains the SSH key we created earlier
 - The environment variable is used to tell git to use the SSH key we added to the runner pod
+
+## The layer uses a private Terraform provider registry
+
+If your stack uses providers from a private Terraform registry, such as a JFrog Artifactory registry, mount Terraform CLI configuration in the runner pod with `overrideRunnerSpec`.
+
+!!! warning
+    Do not enable [Hermitcrab provider caching](../operator-manual/provider-caching.md) for this layer unless you also merge the private registry configuration into the Terraform CLI config generated for Hermitcrab. When Hermitcrab is enabled, Burrito sets `TF_CLI_CONFIG_FILE` in the runner to point to the network mirror configuration, which can override the custom CLI config shown below.
+
+### 1. Create a Secret with Terraform CLI configuration
+
+Create a Kubernetes Secret containing the Terraform CLI configuration file. Replace `terraform-registry.example.com` and the token with the hostname and token for your private registry.
+
+The hostname in the `credentials` block must match the hostname used in the provider `source` address.
+
+```yaml
+apiVersion: v1
+kind: Secret
+metadata:
+  name: terraform-cli-config
+type: Opaque
+stringData:
+  private-provider.tfrc: |
+    credentials "terraform-registry.example.com" {
+      token = "<registry-token>"
+    }
+
+    provider_installation {
+      direct {}
+    }
+```
+
+The minimal `provider_installation` configuration keeps the default direct provider installation behavior.
+
+### 2. Mount the file in the runner configuration
+
+Mount the file in the runner home directory and point `TF_CLI_CONFIG_FILE` to the mounted `*.tfrc` file.
+
+```yaml
+apiVersion: config.terraform.padok.cloud/v1alpha1
+kind: TerraformLayer
+metadata:
+  name: private-provider-registry
+spec:
+  terraform:
+    enabled: true
+    version: "1.6.6"
+  path: "terraform/private-provider"
+  branch: main
+  repository:
+    name: burrito
+    namespace: burrito
+  overrideRunnerSpec:
+    env:
+    - name: TF_CLI_CONFIG_FILE
+      value: /home/burrito/private-provider.tfrc
+    volumes:
+    - name: terraform-cli-config
+      secret:
+        secretName: terraform-cli-config
+    volumeMounts:
+    - name: terraform-cli-config
+      mountPath: /home/burrito/private-provider.tfrc
+      subPath: private-provider.tfrc
+      readOnly: true
+```
+
+Terraform will use `/home/burrito/private-provider.tfrc` as its CLI configuration during `terraform init`, including the private registry credentials and provider installation configuration.


### PR DESCRIPTION
## Summary

- Document how to configure a TerraformLayer runner for private Terraform provider registries.
- Show a Secret-backed Terraform CLI config with registry credentials and direct provider installation.
- Warn that Hermitcrab provider caching overrides TF_CLI_CONFIG_FILE unless the configs are merged.

## Validation

- python -m mkdocs build --strict

Closes #551