### PR TITLE
feat: add non-destructive apply strategy

### DIFF
--- a/api/v1alpha1/common.go
+++ b/api/v1alpha1/common.go
@@ -44,6 +44,7 @@ type RunHistoryPolicy struct {
 
 type RemediationStrategy struct {
 	AutoApply                *bool                      `json:"autoApply,omitempty"`
+	NonDestructiveApply      *bool                      `json:"nonDestructiveApply,omitempty"`
 	ApplyWithoutPlanArtifact *bool                      `json:"applyWithoutPlanArtifact,omitempty"`
 	OnError                  OnErrorRemediationStrategy `json:"onError,omitempty"`
 }
@@ -136,6 +137,10 @@ func GetApplyWithoutPlanArtifactEnabled(repository *TerraformRepository, layer *
 
 func GetAutoApplyEnabled(repo *TerraformRepository, layer *TerraformLayer) bool {
 	return chooseBool(repo.Spec.RemediationStrategy.AutoApply, layer.Spec.RemediationStrategy.AutoApply, false)
+}
+
+func GetNonDestructiveApplyEnabled(repo *TerraformRepository, layer *TerraformLayer) bool {
+	return chooseBool(repo.Spec.RemediationStrategy.NonDestructiveApply, layer.Spec.RemediationStrategy.NonDestructiveApply, false)
 }
 
 func isEnabled(enabled *bool) bool {

--- a/api/v1alpha1/common_test.go
+++ b/api/v1alpha1/common_test.go
@@ -631,6 +631,91 @@ func TestGetAutoApplyEnabled(t *testing.T) {
 	}
 }
 
+func TestGetNonDestructiveApplyEnabled(t *testing.T) {
+	tt := []struct {
+		name       string
+		repository *configv1alpha1.TerraformRepository
+		layer      *configv1alpha1.TerraformLayer
+		expected   bool
+	}{
+		{
+			"EnabledInRepositoryDisabledInLayer",
+			&configv1alpha1.TerraformRepository{
+				Spec: configv1alpha1.TerraformRepositorySpec{
+					RemediationStrategy: configv1alpha1.RemediationStrategy{
+						NonDestructiveApply: &[]bool{true}[0],
+					},
+				},
+			},
+			&configv1alpha1.TerraformLayer{
+				Spec: configv1alpha1.TerraformLayerSpec{
+					RemediationStrategy: configv1alpha1.RemediationStrategy{
+						NonDestructiveApply: &[]bool{false}[0],
+					},
+				},
+			},
+			false,
+		},
+		{
+			"DisabledInRepositoryEnabledInLayer",
+			&configv1alpha1.TerraformRepository{
+				Spec: configv1alpha1.TerraformRepositorySpec{
+					RemediationStrategy: configv1alpha1.RemediationStrategy{
+						NonDestructiveApply: &[]bool{false}[0],
+					},
+				},
+			},
+			&configv1alpha1.TerraformLayer{
+				Spec: configv1alpha1.TerraformLayerSpec{
+					RemediationStrategy: configv1alpha1.RemediationStrategy{
+						NonDestructiveApply: &[]bool{true}[0],
+					},
+				},
+			},
+			true,
+		},
+		{
+			"OnlyRepositoryEnabling",
+			&configv1alpha1.TerraformRepository{
+				Spec: configv1alpha1.TerraformRepositorySpec{
+					RemediationStrategy: configv1alpha1.RemediationStrategy{
+						NonDestructiveApply: &[]bool{true}[0],
+					},
+				},
+			},
+			&configv1alpha1.TerraformLayer{},
+			true,
+		},
+		{
+			"OnlyLayerEnabling",
+			&configv1alpha1.TerraformRepository{},
+			&configv1alpha1.TerraformLayer{
+				Spec: configv1alpha1.TerraformLayerSpec{
+					RemediationStrategy: configv1alpha1.RemediationStrategy{
+						NonDestructiveApply: &[]bool{true}[0],
+					},
+				},
+			},
+			true,
+		},
+		{
+			"Default",
+			&configv1alpha1.TerraformRepository{},
+			&configv1alpha1.TerraformLayer{},
+			false,
+		},
+	}
+
+	for _, tc := range tt {
+		t.Run(tc.name, func(t *testing.T) {
+			result := configv1alpha1.GetNonDestructiveApplyEnabled(tc.repository, tc.layer)
+			if tc.expected != result {
+				t.Errorf("different enabled status computed: expected %t go %t", tc.expected, result)
+			}
+		})
+	}
+}
+
 func TestOverrideRunnerSpec(t *testing.T) {
 	tt := []struct {
 		name         string

--- a/api/v1alpha1/zz_generated.deepcopy.go
+++ b/api/v1alpha1/zz_generated.deepcopy.go
@@ -268,6 +268,11 @@ func (in *RemediationStrategy) DeepCopyInto(out *RemediationStrategy) {
 		*out = new(bool)
 		**out = **in
 	}
+	if in.NonDestructiveApply != nil {
+		in, out := &in.NonDestructiveApply, &out.NonDestructiveApply
+		*out = new(bool)
+		**out = **in
+	}
 	if in.ApplyWithoutPlanArtifact != nil {
 		in, out := &in.ApplyWithoutPlanArtifact, &out.ApplyWithoutPlanArtifact
 		*out = new(bool)

--- a/deploy/charts/burrito/templates/crds/config.terraform.padok.cloud_terraformlayers.yaml
+++ b/deploy/charts/burrito/templates/crds/config.terraform.padok.cloud_terraformlayers.yaml
@@ -4867,6 +4867,8 @@ spec:
                     type: boolean
                   autoApply:
                     type: boolean
+                  nonDestructiveApply:
+                    type: boolean
                   onError:
                     properties:
                       maxRetries:

--- a/deploy/charts/burrito/templates/crds/config.terraform.padok.cloud_terraformrepositories.yaml
+++ b/deploy/charts/burrito/templates/crds/config.terraform.padok.cloud_terraformrepositories.yaml
@@ -4854,6 +4854,8 @@ spec:
                     type: boolean
                   autoApply:
                     type: boolean
+                  nonDestructiveApply:
+                    type: boolean
                   onError:
                     properties:
                       maxRetries:

--- a/docs/user-guide/remediation-strategy.md
+++ b/docs/user-guide/remediation-strategy.md
@@ -8,13 +8,17 @@ The configuration of the `TerraformLayer` will take precedence.
 
 ## `spec.remediationStrategy` API reference
 
-|        Field         |  Type   |                    Default                    |                                  Effect                                   |
-| :------------------: | :-----: | :-------------------------------------------: | :-----------------------------------------------------------------------: |
-|     `autoApply`      | Boolean |                    `false`                    |       If `true` when a `plan` shows drift, it will run an `apply`.        |
-| `onError.maxRetries` | Integer | `5` or value defined in Burrito configuration | How many times Burrito should retry a `plan`/`apply` when a runner fails. |
+|         Field         |  Type   |                    Default                    |                                           Effect                                            |
+| :-------------------: | :-----: | :-------------------------------------------: | :-----------------------------------------------------------------------------------------: |
+|      `autoApply`      | Boolean |                    `false`                    |                If `true` when a `plan` shows drift, it will run an `apply`.                 |
+| `nonDestructiveApply` | Boolean |                    `false`                    | If `true`, `apply` runs are skipped when the latest `plan` includes resources to destroy.   |
+| `onError.maxRetries`  | Integer | `5` or value defined in Burrito configuration |          How many times Burrito should retry a `plan`/`apply` when a runner fails.          |
 
 !!! warning
     This operator is still experimental. Use `spec.remediationStrategy.autoApply: true` at your own risk.
+
+!!! note
+    `nonDestructiveApply` only applies when `autoApply` is enabled. If the latest plan summary includes resources to delete, Burrito will keep the layer in `ApplyNeeded` and wait for the next drift detection instead of creating an `apply` run.
 
 ## Example
 
@@ -28,6 +32,7 @@ metadata:
 spec:
   remediationStrategy:
     autoApply: true
+    nonDestructiveApply: true
     onError:
       maxRetries: 3
   # ... snipped ...

--- a/internal/controllers/terraformlayer/controller.go
+++ b/internal/controllers/terraformlayer/controller.go
@@ -121,6 +121,7 @@ func (r *Reconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Resu
 			lastResult = []byte("Error getting last Result")
 		}
 	}
+	layer.Status.LastResult = string(lastResult)
 	result, run := state.getHandler()(ctx, r, layer, repository)
 	lastRun := layer.Status.LastRun
 	runHistory := layer.Status.LatestRuns

--- a/internal/controllers/terraformlayer/states.go
+++ b/internal/controllers/terraformlayer/states.go
@@ -3,6 +3,7 @@ package terraformlayer
 import (
 	"context"
 	"fmt"
+	"regexp"
 	"strings"
 
 	configv1alpha1 "github.com/padok-team/burrito/api/v1alpha1"
@@ -90,12 +91,20 @@ func (s *PlanNeeded) getHandler() Handler {
 
 type ApplyNeeded struct{}
 
+var deleteChangesRegex = regexp.MustCompile(`\b[1-9][0-9]* to delete\b`)
+
 func (s *ApplyNeeded) getHandler() Handler {
 	return func(ctx context.Context, r *Reconciler, layer *configv1alpha1.TerraformLayer, repository *configv1alpha1.TerraformRepository) (ctrl.Result, *configv1alpha1.TerraformRun) {
 		log := log.WithContext(ctx)
 		autoApply := configv1alpha1.GetAutoApplyEnabled(repository, layer)
 		if !autoApply {
 			log.Infof("autoApply is disabled for layer %s, no apply action taken", layer.Name)
+			return ctrl.Result{RequeueAfter: r.Config.Controller.Timers.DriftDetection}, nil
+		}
+		nonDestructiveApply := configv1alpha1.GetNonDestructiveApplyEnabled(repository, layer)
+		if nonDestructiveApply && hasDestructiveChanges(layer.Status.LastResult) {
+			log.Infof("nonDestructiveApply is enabled for layer %s and the plan contains delete actions, no apply action taken", layer.Name)
+			r.Recorder.Event(layer, corev1.EventTypeNormal, "Reconciliation", "nonDestructiveApply is enabled and the plan contains delete actions, Apply run not created")
 			return ctrl.Result{RequeueAfter: r.Config.Controller.Timers.DriftDetection}, nil
 		}
 		// Check for sync windows that would block the apply action
@@ -118,6 +127,10 @@ func (s *ApplyNeeded) getHandler() Handler {
 		r.Recorder.Event(layer, corev1.EventTypeNormal, "Reconciliation", "Created TerraformRun for Apply action")
 		return ctrl.Result{RequeueAfter: r.Config.Controller.Timers.WaitAction}, &run
 	}
+}
+
+func hasDestructiveChanges(lastResult string) bool {
+	return deleteChangesRegex.MatchString(lastResult)
 }
 
 type MaxRetriesReached struct{}

--- a/internal/controllers/terraformlayer/states_test.go
+++ b/internal/controllers/terraformlayer/states_test.go
@@ -5,13 +5,20 @@ import (
 	"errors"
 	"strings"
 	"testing"
+	"time"
 
 	configv1alpha1 "github.com/padok-team/burrito/api/v1alpha1"
 	"github.com/padok-team/burrito/internal/annotations"
 	"github.com/padok-team/burrito/internal/burrito/config"
+	datastore "github.com/padok-team/burrito/internal/datastore/client"
+	coordinationv1 "k8s.io/api/coordination/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/client-go/tools/record"
 	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 )
 
 type createErrorClient struct {
@@ -21,6 +28,23 @@ type createErrorClient struct {
 
 func (c createErrorClient) Create(context.Context, client.Object, ...client.CreateOption) error {
 	return c.err
+}
+
+type fixedClock struct {
+	now time.Time
+}
+
+func (c fixedClock) Now() time.Time {
+	return c.now
+}
+
+type planDatastoreClient struct {
+	*datastore.MockClient
+	plan []byte
+}
+
+func (c planDatastoreClient) GetPlan(string, string, string, string, string) ([]byte, error) {
+	return c.plan, nil
 }
 
 func TestPlanNeededEventIncludesCreateError(t *testing.T) {
@@ -130,6 +154,119 @@ func TestApplyNeededBlocksDestructivePlanWhenNonDestructiveApplyEnabled(t *testi
 		t.Fatalf("expected DriftDetection requeue, got %s", result.RequeueAfter)
 	}
 	assertEventContains(t, recorder, "nonDestructiveApply is enabled and the plan contains delete actions, Apply run not created")
+}
+
+func TestReconcileBlocksDestructiveFreshPlanWhenNonDestructiveApplyEnabled(t *testing.T) {
+	scheme := runtime.NewScheme()
+	if err := configv1alpha1.AddToScheme(scheme); err != nil {
+		t.Fatalf("failed to register config scheme: %s", err)
+	}
+	if err := coordinationv1.AddToScheme(scheme); err != nil {
+		t.Fatalf("failed to register coordination scheme: %s", err)
+	}
+
+	autoApply := true
+	nonDestructiveApply := true
+	terraformEnabled := true
+	planDate := "Mon May  8 11:21:53 UTC 2023"
+	now, err := time.Parse(time.UnixDate, planDate)
+	if err != nil {
+		t.Fatalf("failed to parse test time: %s", err)
+	}
+	layer := &configv1alpha1.TerraformLayer{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "test-layer",
+			Namespace: "default",
+			Annotations: map[string]string{
+				annotations.LastBranchCommit:   "abc123",
+				annotations.LastRelevantCommit: "abc123",
+				annotations.LastPlanCommit:     "abc123",
+				annotations.LastPlanDate:       planDate,
+				annotations.LastPlanRun:        "plan-run/0",
+				annotations.LastPlanSum:        "plan-sum",
+			},
+		},
+		Spec: configv1alpha1.TerraformLayerSpec{
+			Path: "test-layer/",
+			Repository: configv1alpha1.TerraformLayerRepository{
+				Name:      "test-repo",
+				Namespace: "default",
+			},
+			TerraformConfig: configv1alpha1.TerraformConfig{
+				Enabled: &terraformEnabled,
+			},
+			RemediationStrategy: configv1alpha1.RemediationStrategy{
+				AutoApply:           &autoApply,
+				NonDestructiveApply: &nonDestructiveApply,
+			},
+		},
+		Status: configv1alpha1.TerraformLayerStatus{
+			LastResult: "Plan: 0 to create, 0 to update, 0 to delete",
+			LastRun: configv1alpha1.TerraformLayerRun{
+				Name: "plan-run",
+			},
+		},
+	}
+	repository := &configv1alpha1.TerraformRepository{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "test-repo",
+			Namespace: "default",
+		},
+	}
+	planRun := &configv1alpha1.TerraformRun{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "plan-run",
+			Namespace: "default",
+		},
+		Status: configv1alpha1.TerraformRunStatus{
+			State: "Succeeded",
+		},
+	}
+	fakeClient := fake.NewClientBuilder().
+		WithScheme(scheme).
+		WithObjects(layer, repository, planRun).
+		WithStatusSubresource(&configv1alpha1.TerraformLayer{}).
+		Build()
+	reconciler := &Reconciler{
+		Client: fakeClient,
+		Clock:  fixedClock{now: now},
+		Config: config.TestConfig(),
+		Datastore: planDatastoreClient{
+			MockClient: datastore.NewMockClient(),
+			plan:       []byte("Plan: 0 to create, 1 to update, 2 to delete"),
+		},
+		Recorder: record.NewFakeRecorder(1),
+	}
+
+	result, err := reconciler.Reconcile(context.Background(), reconcile.Request{
+		NamespacedName: types.NamespacedName{
+			Name:      layer.Name,
+			Namespace: layer.Namespace,
+		},
+	})
+
+	if err != nil {
+		t.Fatalf("expected no reconcile error, got %s", err)
+	}
+	if result.RequeueAfter != reconciler.Config.Controller.Timers.DriftDetection {
+		t.Fatalf("expected DriftDetection requeue, got %s", result.RequeueAfter)
+	}
+	updatedLayer := &configv1alpha1.TerraformLayer{}
+	if err := fakeClient.Get(context.Background(), types.NamespacedName{Name: layer.Name, Namespace: layer.Namespace}, updatedLayer); err != nil {
+		t.Fatalf("failed to fetch updated layer: %s", err)
+	}
+	if updatedLayer.Status.LastResult != "Plan: 0 to create, 1 to update, 2 to delete" {
+		t.Fatalf("expected fresh plan result in status, got %q", updatedLayer.Status.LastResult)
+	}
+	runs := &configv1alpha1.TerraformRunList{}
+	if err := fakeClient.List(context.Background(), runs); err != nil {
+		t.Fatalf("failed to list runs: %s", err)
+	}
+	for _, run := range runs.Items {
+		if run.Spec.Action == string(ApplyAction) {
+			t.Fatalf("expected no apply run, got %s", run.Name)
+		}
+	}
 }
 
 func TestHasDestructiveChanges(t *testing.T) {

--- a/internal/controllers/terraformlayer/states_test.go
+++ b/internal/controllers/terraformlayer/states_test.go
@@ -90,6 +90,70 @@ func TestApplyNeededEventIncludesCreateError(t *testing.T) {
 	assertEventContains(t, recorder, "Failed to create TerraformRun for Apply action: "+createErr.Error())
 }
 
+func TestApplyNeededBlocksDestructivePlanWhenNonDestructiveApplyEnabled(t *testing.T) {
+	recorder := record.NewFakeRecorder(1)
+	reconciler := &Reconciler{
+		Client:   createErrorClient{err: errors.New("unexpected create")},
+		Recorder: recorder,
+		Config:   config.TestConfig(),
+	}
+	autoApply := true
+	nonDestructiveApply := true
+	layer := &configv1alpha1.TerraformLayer{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "test-layer",
+			Namespace: "default",
+			Annotations: map[string]string{
+				annotations.LastRelevantCommit: "abc123",
+				annotations.LastPlanRun:        "plan-run/0",
+			},
+		},
+		Status: configv1alpha1.TerraformLayerStatus{
+			LastResult: "Plan: 0 to create, 1 to update, 2 to delete",
+		},
+	}
+	repository := &configv1alpha1.TerraformRepository{
+		Spec: configv1alpha1.TerraformRepositorySpec{
+			RemediationStrategy: configv1alpha1.RemediationStrategy{
+				AutoApply:           &autoApply,
+				NonDestructiveApply: &nonDestructiveApply,
+			},
+		},
+	}
+
+	result, run := (&ApplyNeeded{}).getHandler()(context.Background(), reconciler, layer, repository)
+
+	if run != nil {
+		t.Fatalf("expected no run when nonDestructiveApply blocks destructive changes")
+	}
+	if result.RequeueAfter != reconciler.Config.Controller.Timers.DriftDetection {
+		t.Fatalf("expected DriftDetection requeue, got %s", result.RequeueAfter)
+	}
+	assertEventContains(t, recorder, "nonDestructiveApply is enabled and the plan contains delete actions, Apply run not created")
+}
+
+func TestHasDestructiveChanges(t *testing.T) {
+	tt := []struct {
+		name       string
+		lastResult string
+		expected   bool
+	}{
+		{"NoDelete", "Plan: 3 to create, 1 to update, 0 to delete", false},
+		{"OneDelete", "Plan: 0 to create, 0 to update, 1 to delete", true},
+		{"MultipleDeletes", "Plan: 0 to create, 1 to update, 12 to delete", true},
+		{"NoPlan", "Layer has never been planned", false},
+	}
+
+	for _, tc := range tt {
+		t.Run(tc.name, func(t *testing.T) {
+			result := hasDestructiveChanges(tc.lastResult)
+			if result != tc.expected {
+				t.Fatalf("expected %t, got %t", tc.expected, result)
+			}
+		})
+	}
+}
+
 func assertEventContains(t *testing.T, recorder *record.FakeRecorder, want string) {
 	t.Helper()
 

--- a/manifests/crds/config.terraform.padok.cloud_terraformlayers.yaml
+++ b/manifests/crds/config.terraform.padok.cloud_terraformlayers.yaml
@@ -4866,6 +4866,8 @@ spec:
                     type: boolean
                   autoApply:
                     type: boolean
+                  nonDestructiveApply:
+                    type: boolean
                   onError:
                     properties:
                       maxRetries:

--- a/manifests/crds/config.terraform.padok.cloud_terraformrepositories.yaml
+++ b/manifests/crds/config.terraform.padok.cloud_terraformrepositories.yaml
@@ -4853,6 +4853,8 @@ spec:
                     type: boolean
                   autoApply:
                     type: boolean
+                  nonDestructiveApply:
+                    type: boolean
                   onError:
                     properties:
                       maxRetries:

--- a/manifests/install.yaml
+++ b/manifests/install.yaml
@@ -4866,6 +4866,8 @@ spec:
                     type: boolean
                   autoApply:
                     type: boolean
+                  nonDestructiveApply:
+                    type: boolean
                   onError:
                     properties:
                       maxRetries:
@@ -10005,6 +10007,8 @@ spec:
                   applyWithoutPlanArtifact:
                     type: boolean
                   autoApply:
+                    type: boolean
+                  nonDestructiveApply:
                     type: boolean
                   onError:
                     properties:


### PR DESCRIPTION
Closes #559

## What changes did you make?

Adds `spec.remediationStrategy.nonDestructiveApply` to TerraformLayer and TerraformRepository.

When both `autoApply` and `nonDestructiveApply` are enabled, Burrito skips creating an apply TerraformRun if the latest plan summary includes resources to delete.

This also updates the generated CRDs, Helm CRDs, static install manifest, DeepCopy output, and user documentation.

## How has this been tested?

- `go test ./api/v1alpha1`
- `go test ./internal/controllers/terraformlayer -run 'TestApplyNeeded|TestHasDestructiveChanges'`
- `go test ./internal/controllers/terraformlayer -run 'TestReconcileBlocksDestructiveFreshPlanWhenNonDestructiveApplyEnabled|TestApplyNeededBlocksDestructivePlanWhenNonDestructiveApplyEnabled|TestHasDestructiveChanges'`

The full TerraformLayer controller suite ran 133/133 specs successfully on Windows with envtest assets, but failed during envtest teardown because Windows process signaling for `etcd`/`kube-apiserver` is not supported.