### PR TITLE
chore: add release-please for automated versioning (fixes #509)

### DIFF
--- a/.github/workflows/release-please.yaml
+++ b/.github/workflows/release-please.yaml
@@ -1,0 +1,20 @@
+name: Release Please
+
+on:
+  push:
+    branches:
+      - main
+
+permissions:
+  contents: write
+  pull-requests: write
+
+jobs:
+  release-please:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: googleapis/release-please-action@v4
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          release-type: simple
+          package-name: burrito

--- a/.release-please-config.json
+++ b/.release-please-config.json
@@ -1,0 +1,20 @@
+{
+  "packages": [
+    {
+      "name": "burrito",
+      "repository": "padok-team/burrito",
+      "package-name": "burrito",
+      "release-type": "simple",
+      "bump-minor-pre-major": true,
+      "bump-patch-for-minor-pre-major": true,
+      "changelog-sections": [
+        { "type": "feat", "section": "Features" },
+        { "type": "fix", "section": "Bug Fixes" },
+        { "type": "chore", "section": "Miscellaneous Chores" },
+        { "type": "docs", "section": "Documentation" },
+        { "type": "refactor", "section": "Code Refactoring" },
+        { "type": "test", "section": "Tests" }
+      ]
+    }
+  ]
+}

--- a/.release-please-manifest.json
+++ b/.release-please-manifest.json
@@ -1,0 +1,5 @@
+{
+  "packages": {
+    "burrito": "v0.12.0"
+  }
+}


### PR DESCRIPTION
## Summary
Adds [release-please](https://github.com/googleapis/release-please) to automate the release workflow.

## Changes
- Adds `.release-please-config.json` - configures changelog sections and release type
- Adds `.release-please-manifest.json` - tracks current version
- Adds `.github/workflows/release-please.yaml` - GitHub Actions workflow

## How it works
1. PRs merged to `main` with conventional commit titles (`feat:`, `fix:`, `chore:`, etc.) trigger release-please
2. Release-please creates a release PR with auto-generated CHANGELOG
3. When the release PR is merged, a GitHub release is created automatically

## Why
The current process requires manual tagging. Release-please handles version bumping and CHANGELOG generation automatically, reducing maintainer toil.

Fixes #509