### PR TITLE
test(config): cover CLI flag precedence

### DIFF
--- a/internal/burrito/config/config.go
+++ b/internal/burrito/config/config.go
@@ -143,6 +143,29 @@ type SecretConfig struct {
 	SecretKey  string `mapstructure:"secretKey"`
 }
 
+var flagConfigKeys = map[string]string{
+	"addr":                       "server.addr",
+	"credentials-ttl":            "controller.timers.credentialsTTL",
+	"drift-detection-period":     "controller.timers.driftDetection",
+	"failure-grace-period":       "controller.timers.failureGracePeriod",
+	"health-probe-bind-address":  "controller.healthProbeBindAddress",
+	"kubernetes-webhook-port":    "controller.kubernetesWebhookPort",
+	"leader-election":            "controller.leaderElection.enabled",
+	"leader-election-id":         "controller.leaderElection.id",
+	"max-concurrent-reconciles":  "controller.maxConcurrentReconciles",
+	"max-concurrent-runner-pods": "controller.maxConcurrentRunnerPods",
+	"metrics-bind-address":       "controller.metricsBindAddress",
+	"namespaces":                 "controller.namespaces",
+	"on-error-period":            "controller.timers.onError",
+	"repository-path":            "runner.repositoryPath",
+	"repository-sync-period":     "controller.timers.repositorySync",
+	"runner-binary-path":         "runner.runnerBinaryPath",
+	"ssh-known-hosts-cm-name":    "runner.sshKnownHostsConfigMapName",
+	"terraform-max-retries":      "controller.terraformMaxRetries",
+	"types":                      "controller.types",
+	"wait-action-period":         "controller.timers.waitAction",
+}
+
 func (c *Config) Load(flags *pflag.FlagSet) error {
 	v := viper.New()
 
@@ -172,16 +195,21 @@ func (c *Config) Load(flags *pflag.FlagSet) error {
 		name = strings.ReplaceAll(name, "-", "_")
 		return pflag.NormalizedName(name)
 	})
-	err := v.BindPFlags(flags)
-	if err != nil {
-		fmt.Fprintf(os.Stderr, "Error binding flags: %s\n", err)
-		return err
+	for flagName, configKey := range flagConfigKeys {
+		flag := flags.Lookup(flagName)
+		if flag == nil {
+			continue
+		}
+		if err := v.BindPFlag(configKey, flag); err != nil {
+			fmt.Fprintf(os.Stderr, "Error binding flag %q: %s\n", flagName, err)
+			return err
+		}
 	}
 
 	// Nested configuration options set with environment variables use an
 	// underscore as a separator.
 	v.SetEnvKeyReplacer(strings.NewReplacer(".", "_"))
-	err = bindEnvironmentVariables(v, *c)
+	err := bindEnvironmentVariables(v, *c)
 	if err != nil {
 		fmt.Fprintf(os.Stderr, "Error binding environment variables: %s\n", err)
 		return err
@@ -211,7 +239,14 @@ func bindEnvironmentVariables(v *viper.Viper, iface interface{}, parts ...string
 				return err
 			}
 		default:
-			err := v.BindEnv(strings.Join(append(parts, tv), "."))
+			keyParts := append(parts, tv)
+			key := strings.Join(keyParts, ".")
+			envName := "BURRITO_" + strings.ToUpper(strings.Join(keyParts, "_"))
+			if value, exists := os.LookupEnv(envName); exists && value != "" {
+				v.Set(key, value)
+				continue
+			}
+			err := v.BindEnv(key)
 			if err != nil {
 				return err
 			}

--- a/internal/burrito/config/config.go
+++ b/internal/burrito/config/config.go
@@ -143,6 +143,8 @@ type SecretConfig struct {
 	SecretKey  string `mapstructure:"secretKey"`
 }
 
+const envPrefix = "burrito"
+
 var flagConfigKeys = map[string]string{
 	"addr":                       "server.addr",
 	"credentials-ttl":            "controller.timers.credentialsTTL",
@@ -166,6 +168,11 @@ var flagConfigKeys = map[string]string{
 	"wait-action-period":         "controller.timers.waitAction",
 }
 
+func ConfigKeyForFlag(flagName string) (string, bool) {
+	configKey, ok := flagConfigKeys[flagName]
+	return configKey, ok
+}
+
 func (c *Config) Load(flags *pflag.FlagSet) error {
 	v := viper.New()
 
@@ -186,7 +193,7 @@ func (c *Config) Load(flags *pflag.FlagSet) error {
 
 	// burrito can be configured with environment variables that start with
 	// burrito_.
-	v.SetEnvPrefix("burrito")
+	v.SetEnvPrefix(envPrefix)
 	v.AutomaticEnv()
 
 	// Options with dashes in flag names have underscores when set inside a
@@ -241,7 +248,7 @@ func bindEnvironmentVariables(v *viper.Viper, iface interface{}, parts ...string
 		default:
 			keyParts := append(parts, tv)
 			key := strings.Join(keyParts, ".")
-			envName := "BURRITO_" + strings.ToUpper(strings.Join(keyParts, "_"))
+			envName := environmentVariableName(keyParts)
 			if value, exists := os.LookupEnv(envName); exists && value != "" {
 				v.Set(key, value)
 				continue
@@ -253,6 +260,10 @@ func bindEnvironmentVariables(v *viper.Viper, iface interface{}, parts ...string
 		}
 	}
 	return nil
+}
+
+func environmentVariableName(parts []string) string {
+	return strings.ToUpper(envPrefix + "_" + strings.Join(parts, "_"))
 }
 
 func TestConfig() *Config {

--- a/internal/burrito/config/config_test.go
+++ b/internal/burrito/config/config_test.go
@@ -209,84 +209,84 @@ func TestConfig_EnvVarOverrides(t *testing.T) {
 	assert.Equal(t, expected, cfg)
 }
 
-// TODO: make that test pass
-// func TestConfig_FlagOverrides(t *testing.T) {
-// 	// Read the test configuration file
-// 	configFile, err := os.ReadFile("testdata/test-config-1.yaml")
-// 	if err != nil {
-// 		t.Fatalf("failed to read test configuration file: %v", err)
-// 	}
+func TestConfig_FlagOverridesFile(t *testing.T) {
+	configFile, err := os.ReadFile("testdata/test-config-1.yaml")
+	if err != nil {
+		t.Fatalf("failed to read test configuration file: %v", err)
+	}
 
-// 	err = os.WriteFile("config.yaml", configFile, 0644)
-// 	if err != nil {
-// 		t.Fatalf("failed to create test configuration file: %v", err)
-// 	}
-// 	defer os.Remove("config.yaml")
+	err = os.WriteFile("config.yaml", configFile, 0644)
+	if err != nil {
+		t.Fatalf("failed to create test configuration file: %v", err)
+	}
+	defer os.Remove("config.yaml")
 
-// 	// Create an empty test flag set
-// 	flags := pflag.NewFlagSet("controllers", pflag.ContinueOnError)
-// 	flags.String("drift-detection-period", "1m", "drift-detection-period")
+	cfg := &config.Config{}
+	flags := pflag.NewFlagSet("server", pflag.ContinueOnError)
+	flags.StringVar(&cfg.Server.Addr, "addr", ":8080", "server address")
+	if err := flags.Set("addr", ":8081"); err != nil {
+		t.Fatalf("failed to set flag: %v", err)
+	}
 
-// 	// Create a test config instance
-// 	cfg := &config.Config{}
+	if err := cfg.Load(flags); err != nil {
+		t.Fatalf("failed to load configuration: %v", err)
+	}
 
-// 	// Load the configuration
-// 	err = cfg.Load(flags)
-// 	if err != nil {
-// 		t.Fatalf("failed to load configuration: %v", err)
-// 	}
+	assert.Equal(t, ":8081", cfg.Server.Addr)
+}
 
-// 	// Assert the loaded values
-// 	expected := &config.Config{
-// 		Runner: config.RunnerConfig{
-// 			Action: "apply",
-// 			Layer: config.Layer{
-// 				Name:      "test",
-// 				Namespace: "default",
-// 			},
-// 			Repository: config.RepositoryConfig{
-// 				SSHPrivateKey: "private-key",
-// 				Username:      "test",
-// 				Password:      "password",
-// 			},
-// 			SSHKnownHostsConfigMapName: "burrito-ssh-known-hosts",
-// 		},
-// 		Controller: config.ControllerConfig{
-// 			Namespaces: []string{"default", "burrito"},
-// 			Timers: config.ControllerTimers{
-// 				DriftDetection:     1 * time.Minute,
-// 				OnError:            1 * time.Minute,
-// 				WaitAction:         1 * time.Minute,
-// 				FailureGracePeriod: 15 * time.Second,
-// 			},
-// 			Types: []string{"layer", "repository", "pullrequest"},
-// 			LeaderElection: config.LeaderElectionConfig{
-// 				Enabled: true,
-// 				ID:      "6d185457.terraform.padok.cloud",
-// 			},
-// 			MetricsBindAddress:     ":8080",
-// 			HealthProbeBindAddress: ":8081",
-// 			KubernetesWebhookPort:  9443,
-// 			GithubConfig: config.GithubConfig{
-// 				APIToken: "github-token",
-// 			},
-// 			GitlabConfig: config.GitlabConfig{
-// 				APIToken: "gitlab-token",
-// 				URL:      "https://gitlab.example.com",
-// 			},
-// 		},
-// 		Server: config.ServerConfig{
-// 			Addr: ":8080",
-// 			Webhook: config.WebhookConfig{
-// 				Github: config.WebhookGithubConfig{
-// 					Secret: "github-secret",
-// 				},
-// 				Gitlab: config.WebhookGitlabConfig{
-// 					Secret: "gitlab-secret",
-// 				},
-// 			},
-// 		},
-// 	}
+func TestConfig_EnvVarOverridesFlag(t *testing.T) {
+	configFile, err := os.ReadFile("testdata/test-config-1.yaml")
+	if err != nil {
+		t.Fatalf("failed to read test configuration file: %v", err)
+	}
 
-// 	assert.Equal(t, expected, cfg)
-// }
+	err = os.WriteFile("config.yaml", configFile, 0644)
+	if err != nil {
+		t.Fatalf("failed to create test configuration file: %v", err)
+	}
+	defer os.Remove("config.yaml")
+
+	t.Setenv("BURRITO_SERVER_ADDR", ":8082")
+
+	cfg := &config.Config{}
+	flags := pflag.NewFlagSet("server", pflag.ContinueOnError)
+	flags.StringVar(&cfg.Server.Addr, "addr", ":8080", "server address")
+	if err := flags.Set("addr", ":8081"); err != nil {
+		t.Fatalf("failed to set flag: %v", err)
+	}
+
+	if err := cfg.Load(flags); err != nil {
+		t.Fatalf("failed to load configuration: %v", err)
+	}
+
+	assert.Equal(t, ":8082", cfg.Server.Addr)
+}
+
+func TestConfig_EmptyEnvVarDoesNotOverrideFlag(t *testing.T) {
+	configFile, err := os.ReadFile("testdata/test-config-1.yaml")
+	if err != nil {
+		t.Fatalf("failed to read test configuration file: %v", err)
+	}
+
+	err = os.WriteFile("config.yaml", configFile, 0644)
+	if err != nil {
+		t.Fatalf("failed to create test configuration file: %v", err)
+	}
+	defer os.Remove("config.yaml")
+
+	t.Setenv("BURRITO_SERVER_ADDR", "")
+
+	cfg := &config.Config{}
+	flags := pflag.NewFlagSet("server", pflag.ContinueOnError)
+	flags.StringVar(&cfg.Server.Addr, "addr", ":8080", "server address")
+	if err := flags.Set("addr", ":8081"); err != nil {
+		t.Fatalf("failed to set flag: %v", err)
+	}
+
+	if err := cfg.Load(flags); err != nil {
+		t.Fatalf("failed to load configuration: %v", err)
+	}
+
+	assert.Equal(t, ":8081", cfg.Server.Addr)
+}

--- a/internal/burrito/config/config_test.go
+++ b/internal/burrito/config/config_test.go
@@ -6,7 +6,10 @@ import (
 	"time"
 
 	configv1alpha1 "github.com/padok-team/burrito/api/v1alpha1"
+	burritocmd "github.com/padok-team/burrito/cmd"
+	"github.com/padok-team/burrito/internal/burrito"
 	"github.com/padok-team/burrito/internal/burrito/config"
+	"github.com/spf13/cobra"
 	"github.com/spf13/pflag"
 	"github.com/stretchr/testify/assert"
 )
@@ -289,4 +292,23 @@ func TestConfig_EmptyEnvVarDoesNotOverrideFlag(t *testing.T) {
 	}
 
 	assert.Equal(t, ":8081", cfg.Server.Addr)
+}
+
+func TestConfig_EveryRegisteredStartFlagHasConfigKey(t *testing.T) {
+	app := &burrito.App{Config: &config.Config{}}
+	rootCmd := burritocmd.New(app)
+
+	walkCommands(rootCmd, func(cmd *cobra.Command) {
+		cmd.Flags().VisitAll(func(flag *pflag.Flag) {
+			_, ok := config.ConfigKeyForFlag(flag.Name)
+			assert.Truef(t, ok, "missing config key for flag %q on command %q", flag.Name, cmd.CommandPath())
+		})
+	})
+}
+
+func walkCommands(cmd *cobra.Command, visit func(*cobra.Command)) {
+	visit(cmd)
+	for _, child := range cmd.Commands() {
+		walkCommands(child, visit)
+	}
 }


### PR DESCRIPTION
## Summary

Fix configuration precedence so explicitly supplied CLI flags override configuration files while environment variables continue to take priority over CLI flags.

## Root cause

The CLI exposes flat flag names such as `--addr`, but Viper was binding those names directly while the corresponding configuration keys are nested, such as `server.addr`. Viper's default precedence also places flags above environment variables, contrary to Burrito's documented precedence.

## Changes

- Map supported CLI flag names to their nested configuration keys.
- Promote explicitly set `BURRITO_*` environment variables above bound flags.
- Add tests for config file, CLI flag, and environment variable precedence.
- Remove the obsolete commented-out flag test.

## Validation

- `go test ./internal/burrito/config`
- `go test -race ./internal/burrito/config`
- `go test ./cmd/... ./internal/burrito/config`
- `go vet ./internal/burrito/config ./cmd/...`
- `git diff --check`

Fixes #146
