### PR TITLE
fix(renovate): lowercase commit subject to satisfy commitlint

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -9,6 +9,7 @@
   "ignorePresets": [
     ":semanticPrefixFixDepsChoreOthers"
   ],
+  "commitMessageLowerCase": "auto",
   "packageRules": [
     {
       "matchManagers": [


### PR DESCRIPTION
## Summary
- The Docker images `packageRule` in `renovate.json` combines `commitMessagePrefix: "chore(docker):"` with a capitalized `groupName: "Docker images"`, producing commits like `chore(docker): Update Docker images`.
- commitlint's `subject-case` rule rejects the capitalized subject after the semantic prefix, failing the `commitlint` CI job on every Renovate PR from this rule (see [PR #924, job 86012600408](https://github.com/padok-team/burrito/actions/runs/28985207297/job/86012600408?pr=924#logs)).
- Adds `"commitMessageLowerCase": "auto"` at the top level, which makes Renovate lowercase the first word of the commit subject after the semantic prefix — fixes this for the Docker images group and any other capitalized `groupName` (`GitHub Actions`, `E2E Docker images`) without changing how groups are displayed in PR titles.

## Test plan
- [ ] Validate `renovate.json` via the Renovate config validator (CI should run this automatically)
- [ ] Confirm the next Renovate-generated commit for a grouped update (e.g. Docker images) has a lowercase subject after the semantic prefix
- [ ] Confirm `commitlint` passes on the next Renovate PR affected by this rule