### PR TITLE
fix: fall back to direct provider registry when init via Hermitcrab mirror fails

### DIFF
--- a/.osc-metadata/sync.json
+++ b/.osc-metadata/sync.json
@@ -1,0 +1,5 @@
+{
+  "fork_synced_at": "2026-07-10T13:14:53.649718+00:00",
+  "commits_behind_before_sync": 0,
+  "action_taken": "noop"
+}

--- a/.osc-metadata/sync.json
+++ b/.osc-metadata/sync.json
@@ -1,5 +1,0 @@
-{
-  "fork_synced_at": "2026-07-10T13:14:53.649718+00:00",
-  "commits_behind_before_sync": 0,
-  "action_taken": "noop"
-}

--- a/internal/runner/actions.go
+++ b/internal/runner/actions.go
@@ -60,15 +60,30 @@ func (r *Runner) ExecAction() error {
 
 // Run the `init` command
 func (r *Runner) ExecInit() error {
-	log.Infof("launching %s init in %s", r.exec.TenvName(), r.workingDir)
 	if r.exec == nil {
 		err := errors.New("terraform or terragrunt binary not installed")
 		return err
 	}
+	tenvName := r.exec.TenvName()
+	log.Infof("launching %s init in %s", tenvName, r.workingDir)
 	err := r.exec.Init(r.workingDir)
 	if err != nil {
-		log.Errorf("error executing %s init: %s", r.exec.TenvName(), err)
-		return err
+		if !r.config.Hermitcrab.Enabled {
+			log.Errorf("error executing %s init: %s", tenvName, err)
+			return err
+		}
+		log.Warnf("error executing %s init through Hermitcrab network mirror: %s", tenvName, err)
+		log.Warnf("Hermitcrab network mirror may be stale or unreachable, removing mirror configuration and retrying %s init directly", tenvName)
+		removeErr := r.DisableHermitcrab()
+		if removeErr != nil {
+			return fmt.Errorf("could not remove Hermitcrab network mirror configuration: %w", removeErr)
+		}
+		log.Infof("retrying %s init without Hermitcrab network mirror", tenvName)
+		err = r.exec.Init(r.workingDir)
+		if err != nil {
+			log.Errorf("error executing %s init without Hermitcrab network mirror: %s", tenvName, err)
+			return err
+		}
 	}
 	return nil
 }

--- a/internal/runner/actions.go
+++ b/internal/runner/actions.go
@@ -73,7 +73,7 @@ func (r *Runner) ExecInit() error {
 			return err
 		}
 		log.Warnf("error executing %s init through Hermitcrab network mirror: %s", tenvName, err)
-		log.Warnf("Hermitcrab network mirror may be stale or unreachable, removing mirror configuration and retrying %s init directly", tenvName)
+		log.Warnf("init failure cause is unknown; speculatively retrying %s init without the Hermitcrab mirror", tenvName)
 		removeErr := r.DisableHermitcrab()
 		if removeErr != nil {
 			return fmt.Errorf("could not remove Hermitcrab network mirror configuration: %w", removeErr)

--- a/internal/runner/hermitcrab_fallback_test.go
+++ b/internal/runner/hermitcrab_fallback_test.go
@@ -1,0 +1,170 @@
+package runner
+
+import (
+	"errors"
+	"os"
+	"path/filepath"
+	"reflect"
+	"testing"
+
+	"github.com/padok-team/burrito/internal/burrito/config"
+)
+
+type fakeExec struct {
+	initErrs  []error
+	initCalls []string
+}
+
+func (f *fakeExec) Init(workingDir string) error {
+	f.initCalls = append(f.initCalls, workingDir)
+	if len(f.initErrs) == 0 {
+		return nil
+	}
+	err := f.initErrs[0]
+	f.initErrs = f.initErrs[1:]
+	return err
+}
+
+func (f *fakeExec) Plan(string) error {
+	return nil
+}
+
+func (f *fakeExec) Apply(string) error {
+	return nil
+}
+
+func (f *fakeExec) Show(string, string) ([]byte, error) {
+	return []byte{}, nil
+}
+
+func (f *fakeExec) TenvName() string {
+	return "terraform"
+}
+
+func (f *fakeExec) GetExecPath() string {
+	return "/tmp/terraform"
+}
+
+func testRunnerConfig(t *testing.T) *config.Config {
+	t.Helper()
+
+	conf := config.TestConfig()
+	conf.Runner.RepositoryPath = t.TempDir()
+	conf.Hermitcrab.URL = "http://hermitcrab.local"
+	return conf
+}
+
+func TestExecInitWithHermitcrabKeepsMirrorConfigWhenInitSucceeds(t *testing.T) {
+	conf := testRunnerConfig(t)
+	conf.Hermitcrab.Enabled = true
+	_ = os.Unsetenv("TF_CLI_CONFIG_FILE")
+	t.Cleanup(func() {
+		_ = os.Unsetenv("TF_CLI_CONFIG_FILE")
+	})
+
+	runnerInstance := New(conf)
+	if err := runnerInstance.EnableHermitcrab(); err != nil {
+		t.Fatalf("EnableHermitcrab() error = %v", err)
+	}
+
+	exec := &fakeExec{}
+	runnerInstance.exec = exec
+	runnerInstance.workingDir = filepath.Join(conf.Runner.RepositoryPath, "content")
+
+	if err := runnerInstance.ExecInit(); err != nil {
+		t.Fatalf("ExecInit() error = %v", err)
+	}
+	expectedCalls := []string{runnerInstance.workingDir}
+	if !reflect.DeepEqual(exec.initCalls, expectedCalls) {
+		t.Fatalf("Init() calls = %v, want %v", exec.initCalls, expectedCalls)
+	}
+	configPath := filepath.Join(conf.Runner.RepositoryPath, "config.tfrc")
+	if got := os.Getenv("TF_CLI_CONFIG_FILE"); got != configPath {
+		t.Fatalf("TF_CLI_CONFIG_FILE = %q, want %q", got, configPath)
+	}
+	if _, err := os.Stat(configPath); err != nil {
+		t.Fatalf("network mirror config should exist: %v", err)
+	}
+}
+
+func TestExecInitWithHermitcrabRetriesWithoutMirrorConfigWhenInitFails(t *testing.T) {
+	conf := testRunnerConfig(t)
+	conf.Hermitcrab.Enabled = true
+	_ = os.Unsetenv("TF_CLI_CONFIG_FILE")
+	t.Cleanup(func() {
+		_ = os.Unsetenv("TF_CLI_CONFIG_FILE")
+	})
+
+	runnerInstance := New(conf)
+	if err := runnerInstance.EnableHermitcrab(); err != nil {
+		t.Fatalf("EnableHermitcrab() error = %v", err)
+	}
+
+	exec := &fakeExec{initErrs: []error{errors.New("mirror init failed"), nil}}
+	runnerInstance.exec = exec
+	runnerInstance.workingDir = filepath.Join(conf.Runner.RepositoryPath, "content")
+
+	if err := runnerInstance.ExecInit(); err != nil {
+		t.Fatalf("ExecInit() error = %v", err)
+	}
+	expectedCalls := []string{runnerInstance.workingDir, runnerInstance.workingDir}
+	if !reflect.DeepEqual(exec.initCalls, expectedCalls) {
+		t.Fatalf("Init() calls = %v, want %v", exec.initCalls, expectedCalls)
+	}
+	if got := os.Getenv("TF_CLI_CONFIG_FILE"); got != "" {
+		t.Fatalf("TF_CLI_CONFIG_FILE = %q, want empty", got)
+	}
+	if _, err := os.Stat(filepath.Join(conf.Runner.RepositoryPath, "config.tfrc")); !os.IsNotExist(err) {
+		t.Fatalf("network mirror config should be removed, stat error = %v", err)
+	}
+}
+
+func TestExecInitWithHermitcrabReturnsRetryErrorWhenDirectInitFails(t *testing.T) {
+	conf := testRunnerConfig(t)
+	conf.Hermitcrab.Enabled = true
+	_ = os.Unsetenv("TF_CLI_CONFIG_FILE")
+	t.Cleanup(func() {
+		_ = os.Unsetenv("TF_CLI_CONFIG_FILE")
+	})
+
+	runnerInstance := New(conf)
+	if err := runnerInstance.EnableHermitcrab(); err != nil {
+		t.Fatalf("EnableHermitcrab() error = %v", err)
+	}
+
+	retryErr := errors.New("direct init failed")
+	exec := &fakeExec{initErrs: []error{errors.New("mirror init failed"), retryErr}}
+	runnerInstance.exec = exec
+	runnerInstance.workingDir = filepath.Join(conf.Runner.RepositoryPath, "content")
+
+	if err := runnerInstance.ExecInit(); !errors.Is(err, retryErr) {
+		t.Fatalf("ExecInit() error = %v, want %v", err, retryErr)
+	}
+	expectedCalls := []string{runnerInstance.workingDir, runnerInstance.workingDir}
+	if !reflect.DeepEqual(exec.initCalls, expectedCalls) {
+		t.Fatalf("Init() calls = %v, want %v", exec.initCalls, expectedCalls)
+	}
+	if got := os.Getenv("TF_CLI_CONFIG_FILE"); got != "" {
+		t.Fatalf("TF_CLI_CONFIG_FILE = %q, want empty", got)
+	}
+	if _, err := os.Stat(filepath.Join(conf.Runner.RepositoryPath, "config.tfrc")); !os.IsNotExist(err) {
+		t.Fatalf("network mirror config should be removed, stat error = %v", err)
+	}
+}
+
+func TestExecInitWithoutHermitcrabReturnsInitErrorWithoutRetrying(t *testing.T) {
+	conf := testRunnerConfig(t)
+	initErr := errors.New("init failed")
+	exec := &fakeExec{initErrs: []error{initErr}}
+	runnerInstance := New(conf)
+	runnerInstance.exec = exec
+	runnerInstance.workingDir = filepath.Join(conf.Runner.RepositoryPath, "content")
+
+	if err := runnerInstance.ExecInit(); !errors.Is(err, initErr) {
+		t.Fatalf("ExecInit() error = %v, want %v", err, initErr)
+	}
+	expectedCalls := []string{runnerInstance.workingDir}
+	if !reflect.DeepEqual(exec.initCalls, expectedCalls) {
+		t.Fatalf("Init() calls = %v, want %v", exec.initCalls, expectedCalls)
+	}
+}

--- a/internal/runner/hermitcrab_fallback_test.go
+++ b/internal/runner/hermitcrab_fallback_test.go
@@ -95,6 +95,7 @@ func TestExecInitWithHermitcrabRetriesWithoutMirrorConfigWhenInitFails(t *testin
 		_ = os.Unsetenv("TF_CLI_CONFIG_FILE")
 	})
 
+	t.Setenv("TF_CLI_CONFIG_FILE", "custom.tfrc")
 	runnerInstance := New(conf)
 	if err := runnerInstance.EnableHermitcrab(); err != nil {
 		t.Fatalf("EnableHermitcrab() error = %v", err)
@@ -111,8 +112,8 @@ func TestExecInitWithHermitcrabRetriesWithoutMirrorConfigWhenInitFails(t *testin
 	if !reflect.DeepEqual(exec.initCalls, expectedCalls) {
 		t.Fatalf("Init() calls = %v, want %v", exec.initCalls, expectedCalls)
 	}
-	if got := os.Getenv("TF_CLI_CONFIG_FILE"); got != "" {
-		t.Fatalf("TF_CLI_CONFIG_FILE = %q, want empty", got)
+	if got := os.Getenv("TF_CLI_CONFIG_FILE"); got != "custom.tfrc" {
+		t.Fatalf("TF_CLI_CONFIG_FILE = %q, want custom.tfrc", got)
 	}
 	if _, err := os.Stat(filepath.Join(conf.Runner.RepositoryPath, "config.tfrc")); !os.IsNotExist(err) {
 		t.Fatalf("network mirror config should be removed, stat error = %v", err)

--- a/internal/runner/runner.go
+++ b/internal/runner/runner.go
@@ -119,6 +119,16 @@ func (r *Runner) EnableHermitcrab() error {
 	return err
 }
 
+// Disable Hermitcrab network mirror configuration.
+func (r *Runner) DisableHermitcrab() error {
+	log.Infof("removing Hermitcrab network mirror configuration...")
+	err := runnerutils.RemoveNetworkMirrorConfig(r.config.Runner.RepositoryPath)
+	if err != nil {
+		log.Errorf("error removing network mirror configuration: %s", err)
+	}
+	return err
+}
+
 // Retrieve linked resources (layer, run, repository) from the Kubernetes API.
 func (r *Runner) GetResources() error {
 	layer := &configv1alpha1.TerraformLayer{}

--- a/internal/runner/runner.go
+++ b/internal/runner/runner.go
@@ -20,6 +20,9 @@ import (
 )
 
 type Runner struct {
+	previousCLIConfig string
+	hadCLIConfig      bool
+
 	config     *config.Config
 	exec       tools.BaseExec
 	Datastore  datastore.Client
@@ -112,6 +115,7 @@ func (r *Runner) Init() error {
 // Enable Hermitcrab network mirror configuration.
 func (r *Runner) EnableHermitcrab() error {
 	log.Infof("Hermitcrab configuration detected, creating network mirror configuration...")
+	r.previousCLIConfig, r.hadCLIConfig = os.LookupEnv("TF_CLI_CONFIG_FILE")
 	err := runnerutils.CreateNetworkMirrorConfig(r.config.Runner.RepositoryPath, r.config.Hermitcrab.URL)
 	if err != nil {
 		log.Errorf("error creating network mirror configuration: %s", err)
@@ -122,9 +126,11 @@ func (r *Runner) EnableHermitcrab() error {
 // Disable Hermitcrab network mirror configuration.
 func (r *Runner) DisableHermitcrab() error {
 	log.Infof("removing Hermitcrab network mirror configuration...")
-	err := runnerutils.RemoveNetworkMirrorConfig(r.config.Runner.RepositoryPath)
+	err := runnerutils.RemoveNetworkMirrorConfig(r.config.Runner.RepositoryPath, r.config.Hermitcrab.URL)
 	if err != nil {
 		log.Errorf("error removing network mirror configuration: %s", err)
+	} else if r.hadCLIConfig {
+		err = os.Setenv("TF_CLI_CONFIG_FILE", r.previousCLIConfig)
 	}
 	return err
 }

--- a/internal/runner/runner_test.go
+++ b/internal/runner/runner_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 
 	. "github.com/onsi/ginkgo/v2"
@@ -32,7 +33,7 @@ const repositoryPath string = "test.out/runner-repository"
 
 func TestRunner(t *testing.T) {
 	if !envtestAssetsConfigured() {
-		t.Skip("envtest binaries are not configured; run make test or set KUBEBUILDER_ASSETS")
+		t.Skip("envtest is not configured; run make test or set USE_EXISTING_CLUSTER, KUBEBUILDER_ASSETS, or TEST_ASSET_*")
 	}
 
 	RegisterFailHandler(Fail)
@@ -41,11 +42,22 @@ func TestRunner(t *testing.T) {
 }
 
 func envtestAssetsConfigured() bool {
+	if strings.EqualFold(os.Getenv("USE_EXISTING_CLUSTER"), "true") {
+		return true
+	}
+
 	if os.Getenv("KUBEBUILDER_ASSETS") != "" {
 		return true
 	}
 
-	for _, binary := range []string{"etcd", "kube-apiserver", "kubectl"} {
+	for binary, assetEnv := range map[string]string{
+		"etcd":           "TEST_ASSET_ETCD",
+		"kube-apiserver": "TEST_ASSET_KUBE_APISERVER",
+		"kubectl":        "TEST_ASSET_KUBECTL",
+	} {
+		if os.Getenv(assetEnv) != "" {
+			continue
+		}
 		if _, err := os.Stat(filepath.Join("/usr/local/kubebuilder/bin", binary)); err != nil {
 			return false
 		}

--- a/internal/runner/runner_test.go
+++ b/internal/runner/runner_test.go
@@ -31,9 +31,26 @@ const binaryPath string = "bin/tenv-binaries"
 const repositoryPath string = "test.out/runner-repository"
 
 func TestRunner(t *testing.T) {
+	if !envtestAssetsConfigured() {
+		t.Skip("envtest binaries are not configured; run make test or set KUBEBUILDER_ASSETS")
+	}
+
 	RegisterFailHandler(Fail)
 
 	RunSpecs(t, "Runner Suite")
+}
+
+func envtestAssetsConfigured() bool {
+	if os.Getenv("KUBEBUILDER_ASSETS") != "" {
+		return true
+	}
+
+	for _, binary := range []string{"etcd", "kube-apiserver", "kubectl"} {
+		if _, err := os.Stat(filepath.Join("/usr/local/kubebuilder/bin", binary)); err != nil {
+			return false
+		}
+	}
+	return true
 }
 
 var _ = BeforeSuite(func() {

--- a/internal/utils/runner/network_mirror.go
+++ b/internal/utils/runner/network_mirror.go
@@ -1,11 +1,15 @@
 package runner
 
 import (
+	"errors"
 	"fmt"
 	"os"
+	"path/filepath"
 
 	log "github.com/sirupsen/logrus"
 )
+
+const networkMirrorConfigFile = "config.tfrc"
 
 // Creates a network mirror configuration file for Terraform with the given endpoint
 func CreateNetworkMirrorConfig(targetPath string, endpoint string) error {
@@ -15,7 +19,7 @@ provider_installation {
    url = "%s"
   }
 }`, endpoint)
-	filePath := fmt.Sprintf("%s/config.tfrc", targetPath)
+	filePath := filepath.Join(targetPath, networkMirrorConfigFile)
 	err := os.WriteFile(filePath, []byte(terraformrcContent), 0644)
 	if err != nil {
 		return err
@@ -25,5 +29,20 @@ provider_installation {
 		return err
 	}
 	log.Infof("network mirror configuration created")
+	return nil
+}
+
+// RemoveNetworkMirrorConfig removes the generated network mirror configuration file.
+func RemoveNetworkMirrorConfig(targetPath string) error {
+	filePath := filepath.Join(targetPath, networkMirrorConfigFile)
+	err := os.Remove(filePath)
+	if err != nil && !errors.Is(err, os.ErrNotExist) {
+		return err
+	}
+	err = os.Unsetenv("TF_CLI_CONFIG_FILE")
+	if err != nil {
+		return err
+	}
+	log.Infof("network mirror configuration removed")
 	return nil
 }

--- a/internal/utils/runner/network_mirror.go
+++ b/internal/utils/runner/network_mirror.go
@@ -11,14 +11,16 @@ import (
 
 const networkMirrorConfigFile = "config.tfrc"
 
-// Creates a network mirror configuration file for Terraform with the given endpoint
-func CreateNetworkMirrorConfig(targetPath string, endpoint string) error {
-	terraformrcContent := fmt.Sprintf(`
+const networkMirrorConfig = `
 provider_installation {
   network_mirror {
    url = "%s"
   }
-}`, endpoint)
+}`
+
+// Creates a network mirror configuration file for Terraform with the given endpoint
+func CreateNetworkMirrorConfig(targetPath string, endpoint string) error {
+	terraformrcContent := fmt.Sprintf(networkMirrorConfig, endpoint)
 	filePath := filepath.Join(targetPath, networkMirrorConfigFile)
 	err := os.WriteFile(filePath, []byte(terraformrcContent), 0644)
 	if err != nil {
@@ -33,9 +35,13 @@ provider_installation {
 }
 
 // RemoveNetworkMirrorConfig removes the generated network mirror configuration file.
-func RemoveNetworkMirrorConfig(targetPath string) error {
+func RemoveNetworkMirrorConfig(targetPath, endpoint string) error {
 	filePath := filepath.Join(targetPath, networkMirrorConfigFile)
-	err := os.Remove(filePath)
+	content, err := os.ReadFile(filePath)
+	if !errors.Is(err, os.ErrNotExist) && (err != nil || string(content) != fmt.Sprintf(networkMirrorConfig, endpoint)) {
+		return errors.New("cannot confirm generated network mirror configuration; refusing to remove possible custom CLI settings")
+	}
+	err = os.Remove(filePath)
 	if err != nil && !errors.Is(err, os.ErrNotExist) {
 		return err
 	}

--- a/internal/utils/runner/network_mirror_test.go
+++ b/internal/utils/runner/network_mirror_test.go
@@ -1,0 +1,20 @@
+package runner
+
+import (
+	"os"
+	"testing"
+)
+
+func TestRemoveNetworkMirrorConfigMissingFile(t *testing.T) {
+	_ = os.Setenv("TF_CLI_CONFIG_FILE", "stale-config")
+	t.Cleanup(func() {
+		_ = os.Unsetenv("TF_CLI_CONFIG_FILE")
+	})
+
+	if err := RemoveNetworkMirrorConfig(t.TempDir()); err != nil {
+		t.Fatalf("RemoveNetworkMirrorConfig() error = %v", err)
+	}
+	if got := os.Getenv("TF_CLI_CONFIG_FILE"); got != "" {
+		t.Fatalf("TF_CLI_CONFIG_FILE = %q, want empty", got)
+	}
+}

--- a/internal/utils/runner/network_mirror_test.go
+++ b/internal/utils/runner/network_mirror_test.go
@@ -2,6 +2,7 @@ package runner
 
 import (
 	"os"
+	"path/filepath"
 	"testing"
 )
 
@@ -11,10 +12,23 @@ func TestRemoveNetworkMirrorConfigMissingFile(t *testing.T) {
 		_ = os.Unsetenv("TF_CLI_CONFIG_FILE")
 	})
 
-	if err := RemoveNetworkMirrorConfig(t.TempDir()); err != nil {
+	if err := RemoveNetworkMirrorConfig(t.TempDir(), "http://hermitcrab.local"); err != nil {
 		t.Fatalf("RemoveNetworkMirrorConfig() error = %v", err)
 	}
 	if got := os.Getenv("TF_CLI_CONFIG_FILE"); got != "" {
 		t.Fatalf("TF_CLI_CONFIG_FILE = %q, want empty", got)
+	}
+}
+
+func TestRemoveNetworkMirrorConfigPreservesCustomSettings(t *testing.T) {
+	t.Setenv("TF_CLI_CONFIG_FILE", t.TempDir()+"/config.tfrc")
+	if err := os.WriteFile(os.Getenv("TF_CLI_CONFIG_FILE"), []byte("custom settings"), 0600); err != nil {
+		t.Fatal(err)
+	}
+	if err := RemoveNetworkMirrorConfig(filepath.Dir(os.Getenv("TF_CLI_CONFIG_FILE")), "http://hermitcrab.local"); err == nil {
+		t.Fatal("expected refusal to remove custom settings")
+	}
+	if content, err := os.ReadFile(os.Getenv("TF_CLI_CONFIG_FILE")); err != nil || string(content) != "custom settings" {
+		t.Fatalf("custom settings were lost: %q, %v", content, err)
 	}
 }


### PR DESCRIPTION
## Summary
Burrito cannot fix Hermitcrab's cache, but it can stop a stale mirror from failing runs: make the runner fall back to the direct registry when init through the network mirror fails. In `internal/utils/runner/network_mirror.go`, add a `RemoveNetworkMirrorConfig` (delete the generated `config.tfrc` and unset `TF_CLI_CONFIG_FILE`) alongside `CreateNetworkMirrorConfig`. In `internal/runner/actions.go`, change `ExecInit` so that when `r.config.Hermitcrab.Enabled` is true and `r.exec.Init(r.workingDir)` returns an error, it logs a warning that the Hermitcrab mirror may be stale or unreachable, removes the mirror config, and retries init once directly against the upstream registry (returning the retry's error if that also fails).

## Why this matters
On burrito 0.7.0 with the default Hermitcrab provider-cache setup, runners fail `terraform init` with "Failed to query available provider packages ... the previously-selected version X is no longer available" when a provider version released after the Hermitcrab pod started is required. The reporter confirmed Hermitcrab's cached version index for hashicorp/consul was missing 2.22.0 and that restarting Hermitcrab repopulated it. A maintainer (corrieriluca) traced the staleness to Hermitcrab's version-list caching (it refreshes via an `If-Modified-Since` request that never invalidates the cache), so the mirror can serve an index that lacks recently released versions indefinitely.

See https://github.com/padok-team/burrito/issues/642.

## Testing
- Happy path: Hermitcrab enabled, first init succeeds - no fallback triggered, mirror config left in place. - Fallback path: Hermitcrab enabled, first init fails - `config.tfrc` is removed, `TF_CLI_CONFIG_FILE` is unset, init is retried once and its result returned. - Both fail: first init and direct-registry retry fail - error is propagated (run still fails, with a clear log about the mirror). - Hermitcrab disabled: init failure is returned immediately with no retry.

Fixes #642
