### PR TITLE
docs: add nested AGENTS.md for internal packages, clarify commit scopes

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -41,6 +41,7 @@ To change CRDs: edit `api/v1alpha1/*_types.go`, then run `make manifests` (and `
 
 - Always check errors explicitly. Never `_ = err` or silently ignored returns.
 - No `panic()` in reconcilers — see `internal/controllers/AGENTS.md`.
+- **Tests:** add new cases to the existing test suite for the package rather than creating a new suite from scratch. Controllers use BDD (ginkgo/gomega) — see `internal/controllers/AGENTS.md`.
 
 ## Commits — Conventional Commits
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -15,6 +15,7 @@ Nested `AGENTS.md` files add directory-specific rules — read them when working
 
 - `api/v1alpha1/` — CRD Go types (see nested AGENTS.md). **Codegen-sensitive.**
 - `internal/controllers/` — reconciliation logic, one package per resource (see nested AGENTS.md).
+- `internal/repository/` — git provider access (see nested AGENTS.md). `internal/runner/` — the Terraform runner binary (see nested AGENTS.md). `internal/datastore/` — artifact storage service (see nested AGENTS.md). `internal/server/` — dashboard server + API (see nested AGENTS.md). `internal/webhook/` — VCS webhook receiver (see nested AGENTS.md).
 - `ui/` — React/Vite/TS dashboard (see nested AGENTS.md).
 - `deploy/charts/burrito/` — Helm chart (see nested AGENTS.md).
 - `cmd/` — binary entrypoints. `hack/` — dev/build scripts. `manifests/` & `config/crd/bases/` — generated manifests. `testdata/` — fixtures. `docs/` — documentation.
@@ -46,4 +47,5 @@ To change CRDs: edit `api/v1alpha1/*_types.go`, then run `make manifests` (and `
 Format: `<type>(<scope>): <description>`.
 
 - **Types:** `feat`, `fix`, `chore`, `docs`, `test`, `refactor`.
-- **Scopes** (use the closest fit): `controller`, `api`, `ui`, `helm`, `ci`, `deps`, `docker`. Scope is optional when none applies.
+- **Scopes** — suggested, not enforced. Prefer the closest fit (`controller`, `api`, `ui`, `helm`, `ci`, `deps`, `docker`); otherwise use another short, relevant scope or omit it.
+- CI gates each commit with commitlint (`@commitlint/config-conventional`) — self-check a message with `npx commitlint`.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -41,7 +41,7 @@ To change CRDs: edit `api/v1alpha1/*_types.go`, then run `make manifests` (and `
 
 - Always check errors explicitly. Never `_ = err` or silently ignored returns.
 - No `panic()` in reconcilers — see `internal/controllers/AGENTS.md`.
-- **Tests:** add new cases to the existing test suite for the package rather than creating a new suite from scratch. Controllers use BDD (ginkgo/gomega) — see `internal/controllers/AGENTS.md`.
+- **Tests:** add new cases to the existing test suite for a package rather than creating a new suite from scratch. Controllers use BDD (ginkgo/gomega): each `controller_test.go` reads `Describe("When X …")` → `It("should Y …")` (run via `RunSpecs`) — add cases to that suite.
 
 ## Commits — Conventional Commits
 

--- a/internal/controllers/AGENTS.md
+++ b/internal/controllers/AGENTS.md
@@ -15,4 +15,3 @@ custom resource: `terraformlayer/`, `terraformrun/`, `terraformrepository/`,
 - Use structured logging via the `logr.Logger` carried in `ctx` (`log.FromContext(ctx)`).
 - Propagate `ctx` and set timeouts on every external call (GitHub, GitLab, Terraform).
 - CRD shapes live in `api/v1alpha1`; never edit generated deepcopy code. After API changes run `make manifests && make generate`.
-- **Tests are BDD.** Each reconciler's `controller_test.go` is a ginkgo/gomega suite written as behaviour specs (`Describe("When X …")` → `It("should Y …")`, run via `RunSpecs`). Add new cases to this existing suite rather than starting a new one from scratch.

--- a/internal/controllers/AGENTS.md
+++ b/internal/controllers/AGENTS.md
@@ -15,3 +15,4 @@ custom resource: `terraformlayer/`, `terraformrun/`, `terraformrepository/`,
 - Use structured logging via the `logr.Logger` carried in `ctx` (`log.FromContext(ctx)`).
 - Propagate `ctx` and set timeouts on every external call (GitHub, GitLab, Terraform).
 - CRD shapes live in `api/v1alpha1`; never edit generated deepcopy code. After API changes run `make manifests && make generate`.
+- **Tests are BDD.** Each reconciler's `controller_test.go` is a ginkgo/gomega suite written as behaviour specs (`Describe("When X …")` → `It("should Y …")`, run via `RunSpecs`). Add new cases to this existing suite rather than starting a new one from scratch.

--- a/internal/datastore/AGENTS.md
+++ b/internal/datastore/AGENTS.md
@@ -1,0 +1,26 @@
+# Scope: Datastore (`internal/datastore/`)
+
+Stores run artifacts (logs, plans, git bundles). Runs as its own binary
+(`cmd/datastore`): an Echo HTTP service (`datastore.go`) fronting a pluggable object store.
+`storage/` holds the backends, `api/` the HTTP handlers, `client/` the client the
+runner/server/controllers use to reach it.
+
+## Rules & Gotchas
+
+- Backends implement `storage.StorageBackend` (`storage/common.go`) — `s3/`, `gcs/`,
+  `azure/`, `mock/`. `storage.New` selects one via a `switch` on config. **Adding a backend =
+  implement the interface AND add a `case`.**
+- Always go through the `Storage` methods (`GetPlan`/`PutPlan`/`GetLogs`/`GetGitBundle`…),
+  **never call `Backend` directly**: `Storage` wraps every read/write with the per-namespace
+  `EncryptionManager` (Put encrypts, Get decrypts). Bypassing it breaks the encryption contract.
+- Object keys are built centrally (`computeLogsKey`/`computePlanKey`/`computeGitBundleKey`) —
+  `layers/ns/layer/run/attempt/<file>`, `repositories/ns/repo/branch/rev.gitbundle`. Don't
+  hand-build keys; keep the format constants and the client in sync.
+- The API is reached over HTTP through `datastore/client`, authorized by Kubernetes
+  ServiceAccount token (audience `burrito`). A change to a handler in `api/` must be mirrored
+  in `client/` (and vice-versa) — they are one contract.
+
+## Validate
+
+`make test` (see `storage/storage_test.go`, `api/api_test.go`), `make vet`,
+`golangci-lint run ./...`.

--- a/internal/datastore/CLAUDE.md
+++ b/internal/datastore/CLAUDE.md
@@ -1,0 +1,1 @@
+AGENTS.md

--- a/internal/repository/AGENTS.md
+++ b/internal/repository/AGENTS.md
@@ -1,0 +1,23 @@
+# Scope: Git Repository Access (`internal/repository/`)
+
+Resolves a `TerraformRepository` to a provider and performs git/API operations against it.
+`repository.go` dispatches on credentials; `providers/` holds the implementations
+(`github/`, `gitlab/`, `standard/`, `mock/`), `credentials/` the `CredentialStore`,
+`types/` the interfaces.
+
+## Rules & Gotchas
+
+- Providers are selected in `GetProviderFromCredentials` (`repository.go`) by
+  `Credential.Provider` (`github`/`gitlab`/`standard`/`mock`). No credentials → public
+  `standard` no-auth. **Adding a provider = add a `case` here AND implement the
+  `types.Provider` interface** (`GetWebhookProvider` / `GetAPIProvider` / `GetGitProvider`).
+- The `standard` provider drives go-git. **Do not use `Repository.Pull()`** — it has a
+  non-fast-forward bug on non-default branches (see `providers/standard/repository_test.go`).
+  Use `Fetch` + hard `Reset`, and always pass `ReferenceName` so go-git targets the right ref.
+- `types.go` is a contract shared with `internal/webhook` (`WebhookProvider`) and
+  `internal/controllers/terraformpullrequest` (`APIProvider`) — changing it ripples there.
+
+## Validate
+
+`make test` (unit tests live beside the code, e.g. `providers/standard/repository_test.go`),
+`make vet`, `golangci-lint run ./...`.

--- a/internal/repository/CLAUDE.md
+++ b/internal/repository/CLAUDE.md
@@ -1,0 +1,1 @@
+AGENTS.md

--- a/internal/runner/AGENTS.md
+++ b/internal/runner/AGENTS.md
@@ -1,0 +1,26 @@
+# Scope: Terraform Runner (`internal/runner/`)
+
+The short-lived binary that actually runs Terraform/Terragrunt. Launched as a Kubernetes Job
+per plan/apply — **not** a controller, there is no reconcile loop. `runner.go` is the
+lifecycle (`Exec`: init clients → fetch code → install binaries → init → action),
+`actions.go` the `plan`/`apply` logic, `tools/` the binary abstraction.
+
+## Rules & Gotchas
+
+- Entry is `Runner.Exec()` and runs **once** then exits. It uses `logrus` (not the
+  controllers' `logr`/`ctx` logging) — match the surrounding style here.
+- Never shell out to `terraform`/`terragrunt` directly: go through `tools.BaseExec`
+  (`Init`/`Plan`/`Apply`/`Show`, `TenvName()`), which resolves versions via tenv. Add tool
+  support under `tools/`.
+- Source code is **not** cloned from the remote: the runner pulls a git bundle from the
+  datastore (`Datastore.GetGitBundle`) and `git clone`s it locally.
+- Artifacts flow through the datastore client keyed by `namespace/name/run/attempt/format`.
+  `plan` writes formats `pretty`/`json`/`short`/`bin`; `apply` reuses the `bin` plan artifact
+  (unless `GetApplyWithoutPlanArtifactEnabled`). Results are surfaced to the layer via
+  `annotations.Add`, not by mutating status directly.
+- `Action` is `plan` or `apply`; an unknown action signals a controller/runner version
+  mismatch — keep the two in sync.
+
+## Validate
+
+`make test` (see `runner_test.go`), `make vet`, `golangci-lint run ./...`.

--- a/internal/runner/CLAUDE.md
+++ b/internal/runner/CLAUDE.md
@@ -1,0 +1,1 @@
+AGENTS.md

--- a/internal/server/AGENTS.md
+++ b/internal/server/AGENTS.md
@@ -1,0 +1,24 @@
+# Scope: Dashboard Server (`internal/server/`)
+
+Serves the `ui/` dashboard and its JSON API. Echo v4 (`server.go`), one binary
+(`cmd/server`). `api/` holds the handlers backing the UI, `auth/` the auth backends.
+
+## Rules & Gotchas
+
+- The UI is embedded with `//go:embed all:dist` — the `ui/` build output must exist
+  (`yarn --cwd ui build`) before the server binary is built, or the embed fails.
+- `/api/*` handlers in `api/` are the contract the `ui/` TypeScript consumes (`/layers`,
+  `/repositories`, `/logs/...`, `/run/.../attempts`, sync). Treat their response shapes like
+  the CRD↔UI contract: **flag breaking changes** and update `ui/` in step.
+- Reads live k8s state via a controller-runtime `client` and run artifacts via the
+  `datastore/client` — the server owns no storage itself.
+- Auth is OIDC (`auth/oauth`) or Basic (`auth/basic`), selected by config; with neither the
+  server is public (it warns). Auth backends implement `auth.AuthHandlers`; sessions are
+  cookie-based (`burrito_session`). Keep new `/api` routes behind `authMiddleware`.
+- `POST /api/webhook` is intentionally unauthenticated (handled by `internal/webhook`);
+  don't move it behind auth.
+
+## Validate
+
+`make test`, `make vet`, `golangci-lint run ./...`. Build needs the UI: `yarn --cwd ui build`
+then `make build`.

--- a/internal/server/CLAUDE.md
+++ b/internal/server/CLAUDE.md
@@ -1,0 +1,1 @@
+AGENTS.md

--- a/internal/webhook/AGENTS.md
+++ b/internal/webhook/AGENTS.md
@@ -1,0 +1,23 @@
+# Scope: VCS Webhook Receiver (`internal/webhook/`)
+
+Handles inbound GitHub/GitLab webhooks, mounted (unauthenticated) at `POST /api/webhook` by
+`internal/server`. `webhook.go` is the dispatch; `event/` the parsed events that mutate k8s.
+
+## Rules & Gotchas
+
+- This package is **provider-agnostic dispatch**, not VCS-specific parsing.
+  `tryGetEventFromPayload` iterates over every known credential (shared + per-repo) and asks
+  each provider's `WebhookProvider.ParseWebhookPayload` to claim the request. The first match
+  wins; no match → `nil` event → HTTP 400.
+- **Signature/secret verification lives in each provider's `ParseWebhookPayload`**
+  (`internal/repository/providers/*`), not here. To add a VCS, implement `WebhookProvider`
+  there and reuse `repo.GetProviderFromCredentials` — do not special-case a provider in this
+  package.
+- The endpoint is unauthenticated by design (secret-based validation is the gate). Keep error
+  responses HTML-escaped (`html.EscapeString`) — the payload is untrusted input reflected back.
+- Parsed events implement `event.Handle(client)`, which updates resources via the
+  controller-runtime client; keep handling idempotent (a webhook can be redelivered).
+
+## Validate
+
+`make test`, `make vet`, `golangci-lint run ./...`.

--- a/internal/webhook/CLAUDE.md
+++ b/internal/webhook/CLAUDE.md
@@ -1,0 +1,1 @@
+AGENTS.md


### PR DESCRIPTION
Cover the previously undocumented internal/ packages (repository, runner, datastore, server, webhook) with scoped agent guidance, so agents editing those areas get the real gotchas (go-git fetch+reset, datastore encryption contract, tenv exec abstraction, UI/API contract, webhook signature verification) instead of only the root file.

Also route to them from the root Monorepo Map, and mark commit scopes as suggested-not-enforced with a pointer to the commitlint CI gate.