### PR TITLE
fix(controller): plan and apply should use last branch commit

### DIFF
--- a/internal/controllers/terraformlayer/controller.go
+++ b/internal/controllers/terraformlayer/controller.go
@@ -117,7 +117,7 @@ func (r *Reconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Resu
 		lastResult, err = r.Datastore.GetPlan(layer.Namespace, layer.Name, layer.Status.LastRun.Name, "", "short")
 		if err != nil {
 			log.Errorf("failed to get plan for layer %s: %s", layer.Name, err)
-			r.Recorder.Event(layer, corev1.EventTypeNormal, "Reconciliation", "Failed to get last Result")
+			r.Recorder.Eventf(layer, corev1.EventTypeNormal, "Reconciliation", "Failed to get last Result: %s", err)
 			lastResult = []byte("Error getting last Result")
 		}
 	}

--- a/internal/controllers/terraformlayer/states.go
+++ b/internal/controllers/terraformlayer/states.go
@@ -70,10 +70,10 @@ func (s *PlanNeeded) getHandler() Handler {
 		if isActionBlocked(r, layer, repository, syncwindow.PlanAction) {
 			return ctrl.Result{RequeueAfter: r.Config.Controller.Timers.WaitAction}, nil
 		}
-		revision, ok := layer.Annotations[annotations.LastRelevantCommit]
+		revision, ok := layer.Annotations[annotations.LastBranchCommit]
 		if !ok {
-			r.Recorder.Event(layer, corev1.EventTypeWarning, "Reconciliation", "Layer has no last relevant commit annotation, Plan run not created")
-			log.Errorf("layer %s has no last relevant commit annotation, run not created", layer.Name)
+			r.Recorder.Event(layer, corev1.EventTypeWarning, "Reconciliation", "Layer has no last branch commit annotation, Plan run not created")
+			log.Errorf("layer %s has no last branch commit annotation, run not created", layer.Name)
 			return ctrl.Result{RequeueAfter: r.Config.Controller.Timers.OnError}, nil
 		}
 		run := r.getRun(layer, revision, PlanAction)
@@ -102,10 +102,10 @@ func (s *ApplyNeeded) getHandler() Handler {
 		if isActionBlocked(r, layer, repository, syncwindow.ApplyAction) {
 			return ctrl.Result{RequeueAfter: r.Config.Controller.Timers.WaitAction}, nil
 		}
-		revision, ok := layer.Annotations[annotations.LastRelevantCommit]
+		revision, ok := layer.Annotations[annotations.LastBranchCommit]
 		if !ok {
-			r.Recorder.Event(layer, corev1.EventTypeWarning, "Reconciliation", "Layer has no last relevant commit annotation, Apply run not created")
-			log.Errorf("layer %s has no last relevant commit annotation, run not created", layer.Name)
+			r.Recorder.Event(layer, corev1.EventTypeWarning, "Reconciliation", "Layer has no last branch commit annotation, Apply run not created")
+			log.Errorf("layer %s has no last branch commit annotation, run not created", layer.Name)
 			return ctrl.Result{RequeueAfter: r.Config.Controller.Timers.OnError}, nil
 		}
 		run := r.getRun(layer, revision, ApplyAction)

--- a/internal/controllers/terraformlayer/states_test.go
+++ b/internal/controllers/terraformlayer/states_test.go
@@ -36,7 +36,7 @@ func TestPlanNeededEventIncludesCreateError(t *testing.T) {
 			Name:      "infra-s3-buckets-logistics-toolings-dc1-nl-prd-defect-tracker-prd-nl1",
 			Namespace: "default",
 			Annotations: map[string]string{
-				annotations.LastRelevantCommit: "abc123",
+				annotations.LastBranchCommit: "abc123",
 			},
 		},
 	}
@@ -66,8 +66,8 @@ func TestApplyNeededEventIncludesCreateError(t *testing.T) {
 			Name:      "infra-s3-buckets-logistics-toolings-dc1-nl-prd-defect-tracker-prd-nl1",
 			Namespace: "default",
 			Annotations: map[string]string{
-				annotations.LastRelevantCommit: "abc123",
-				annotations.LastPlanRun:        "plan-run/0",
+				annotations.LastBranchCommit: "abc123",
+				annotations.LastPlanRun:      "plan-run/0",
 			},
 		},
 	}

--- a/internal/controllers/terraformlayer/testdata/error-case.yaml
+++ b/internal/controllers/terraformlayer/testdata/error-case.yaml
@@ -11,7 +11,7 @@ metadata:
     runner.terraform.padok.cloud/plan-date: Mon May  8 11:21:53 UTC 2023
     runner.terraform.padok.cloud/plan-run: "run-failed/0"
     runner.terraform.padok.cloud/plan-sum: ""
-    webhook.terraform.padok.cloud/relevant-commit: cb9f15b90861c8c4364cdde63d17837c7a9ccca9
+    webhook.terraform.padok.cloud/branch-commit: cb9f15b90861c8c4364cdde63d17837c7a9ccca9
 spec:
   branch: main
   path: error-case-one/
@@ -41,7 +41,7 @@ metadata:
     runner.terraform.padok.cloud/apply-date: Mon May  8 11:21:53 UTC 2023
     runner.terraform.padok.cloud/apply-run: "run-failed/0"
     runner.terraform.padok.cloud/apply-sum: ""
-    webhook.terraform.padok.cloud/relevant-commit: cb9f15b90861c8c4364cdde63d17837c7a9ccca9
+    webhook.terraform.padok.cloud/branch-commit: cb9f15b90861c8c4364cdde63d17837c7a9ccca9
 spec:
   branch: main
   path: error-case-two/
@@ -68,7 +68,7 @@ metadata:
     runner.terraform.padok.cloud/plan-date: Sun May  7 11:21:53 UTC 2023
     runner.terraform.padok.cloud/plan-run: "run-failed/0"
     runner.terraform.padok.cloud/plan-sum: ""
-    webhook.terraform.padok.cloud/relevant-commit: cb9f15b90861c8c4364cdde63d17837c7a9ccca9
+    webhook.terraform.padok.cloud/branch-commit: cb9f15b90861c8c4364cdde63d17837c7a9ccca9
 spec:
   branch: main
   path: error-case-three/
@@ -100,7 +100,7 @@ metadata:
     runner.terraform.padok.cloud/apply-commit: 840046e9db8c1348445d0018c86347967b066df0
     runner.terraform.padok.cloud/apply-date: Mon May  8 11:20:53 UTC 2023
     runner.terraform.padok.cloud/apply-sum: ""
-    webhook.terraform.padok.cloud/relevant-commit: cb9f15b90861c8c4364cdde63d17837c7a9ccca9
+    webhook.terraform.padok.cloud/branch-commit: cb9f15b90861c8c4364cdde63d17837c7a9ccca9
 spec:
   branch: main
   path: error-case-four/
@@ -136,7 +136,7 @@ metadata:
     runner.terraform.padok.cloud/apply-commit: 840046e9db8c1348445d0018c86347967b066df0
     runner.terraform.padok.cloud/apply-date: Mon May  8 11:20:53 UTC 2023
     runner.terraform.padok.cloud/apply-sum: ""
-    webhook.terraform.padok.cloud/relevant-commit: cb9f15b90861c8c4364cdde63d17837c7a9ccca9
+    webhook.terraform.padok.cloud/branch-commit: cb9f15b90861c8c4364cdde63d17837c7a9ccca9
 spec:
   branch: main
   path: error-case-five/
@@ -185,7 +185,7 @@ metadata:
     runner.terraform.padok.cloud/plan-commit: ca9b6c80ac8fb5cd837ae9b374b79ff33f472558
     runner.terraform.padok.cloud/plan-date: Sun May  7 11:21:53 UTC 2023
     runner.terraform.padok.cloud/plan-sum: ""
-    webhook.terraform.padok.cloud/relevant-commit: cb9f15b90861c8c4364cdde63d17837c7a9ccca9
+    webhook.terraform.padok.cloud/branch-commit: cb9f15b90861c8c4364cdde63d17837c7a9ccca9
 spec:
   branch: main
   path: error-case-seven/
@@ -211,7 +211,7 @@ metadata:
     runner.terraform.padok.cloud/plan-commit: ca9b6c80ac8fb5cd837ae9b374b79ff33f472558
     runner.terraform.padok.cloud/plan-date: Sun May  7 11:21:53 UTC 2023
     runner.terraform.padok.cloud/plan-sum: ""
-    webhook.terraform.padok.cloud/relevant-commit: cb9f15b90861c8c4364cdde63d17837c7a9ccca9
+    webhook.terraform.padok.cloud/branch-commit: cb9f15b90861c8c4364cdde63d17837c7a9ccca9
 spec:
   branch: main
   path: error-case-eight/
@@ -240,7 +240,7 @@ metadata:
     runner.terraform.padok.cloud/apply-commit: cb9f15b90861c8c4364cdde63d17837c7a9ccca9
     runner.terraform.padok.cloud/apply-date: Mon May  8 11:20:53 UTC 2023
     runner.terraform.padok.cloud/apply-sum: ""
-    webhook.terraform.padok.cloud/relevant-commit: cb9f15b90861c8c4364cdde63d17837c7a9ccca9
+    webhook.terraform.padok.cloud/branch-commit: cb9f15b90861c8c4364cdde63d17837c7a9ccca9
 spec:
   branch: main
   path: error-case-nine/

--- a/internal/controllers/terraformlayer/testdata/error-case.yaml
+++ b/internal/controllers/terraformlayer/testdata/error-case.yaml
@@ -212,6 +212,7 @@ metadata:
     runner.terraform.padok.cloud/plan-date: Sun May  7 11:21:53 UTC 2023
     runner.terraform.padok.cloud/plan-sum: ""
     webhook.terraform.padok.cloud/branch-commit: cb9f15b90861c8c4364cdde63d17837c7a9ccca9
+    webhook.terraform.padok.cloud/relevant-commit: cb9f15b90861c8c4364cdde63d17837c7a9ccca9
 spec:
   branch: main
   path: error-case-eight/

--- a/internal/controllers/terraformlayer/testdata/merge-case.yaml
+++ b/internal/controllers/terraformlayer/testdata/merge-case.yaml
@@ -4,7 +4,7 @@ metadata:
   name: merge-case-1
   namespace: default
   annotations:
-    webhook.terraform.padok.cloud/relevant-commit: cb9f15b90861c8c4364cdde63d17837c7a9ccca9
+    webhook.terraform.padok.cloud/branch-commit: cb9f15b90861c8c4364cdde63d17837c7a9ccca9
 spec:
   branch: main
   path: merge-case-one/

--- a/internal/controllers/terraformlayer/testdata/nominal-case.yaml
+++ b/internal/controllers/terraformlayer/testdata/nominal-case.yaml
@@ -4,7 +4,7 @@ metadata:
   name: nominal-case-1
   namespace: default
   annotations:
-    webhook.terraform.padok.cloud/relevant-commit: cb9f15b90861c8c4364cdde63d17837c7a9ccca9
+    webhook.terraform.padok.cloud/branch-commit: cb9f15b90861c8c4364cdde63d17837c7a9ccca9
 spec:
   branch: main
   path: nominal-case-one/
@@ -30,7 +30,7 @@ metadata:
     runner.terraform.padok.cloud/plan-date: Mon May  8 11:21:53 UTC 2023
     runner.terraform.padok.cloud/plan-run: run-succeeded/0
     runner.terraform.padok.cloud/plan-sum: AuP6pMNxWsbSZKnxZvxD842wy0qaF9JCX8HW1nFeL1I=
-    webhook.terraform.padok.cloud/relevant-commit: cb9f15b90861c8c4364cdde63d17837c7a9ccca9
+    webhook.terraform.padok.cloud/branch-commit: cb9f15b90861c8c4364cdde63d17837c7a9ccca9
 spec:
   branch: main
   path: nominal-case-two/
@@ -60,7 +60,7 @@ metadata:
     runner.terraform.padok.cloud/plan-date: Mon May  8 11:21:53 UTC 2023
     runner.terraform.padok.cloud/plan-run: run-succeeded/0
     runner.terraform.padok.cloud/plan-sum: AuP6pMNxWsbSZKnxZvxD842wy0qaF9JCX8HW1nFeL1I=
-    webhook.terraform.padok.cloud/relevant-commit: cb9f15b90861c8c4364cdde63d17837c7a9ccca9
+    webhook.terraform.padok.cloud/branch-commit: cb9f15b90861c8c4364cdde63d17837c7a9ccca9
 spec:
   branch: main
   path: nominal-case-three/
@@ -95,7 +95,7 @@ metadata:
     runner.terraform.padok.cloud/apply-commit: ca9b6c80ac8fb5cd837ae9b374b79ff33f472558
     runner.terraform.padok.cloud/apply-date: Mon May  8 11:21:53 UTC 2023
     runner.terraform.padok.cloud/apply-sum: AuP6pMNxWsbSZKnxZvxD842wy0qaF9JCX8HW1nFeL1I=
-    webhook.terraform.padok.cloud/relevant-commit: cb9f15b90861c8c4364cdde63d17837c7a9ccca9
+    webhook.terraform.padok.cloud/branch-commit: cb9f15b90861c8c4364cdde63d17837c7a9ccca9
 spec:
   branch: main
   path: nominal-case-four/
@@ -117,7 +117,7 @@ metadata:
   name: nominal-case-5
   namespace: default
   annotations:
-    webhook.terraform.padok.cloud/relevant-commit: cb9f15b90861c8c4364cdde63d17837c7a9ccca9
+    webhook.terraform.padok.cloud/branch-commit: cb9f15b90861c8c4364cdde63d17837c7a9ccca9
 spec:
   branch: main
   path: shared-path/
@@ -139,7 +139,7 @@ metadata:
   name: nominal-case-5-shared-path
   namespace: default
   annotations:
-    webhook.terraform.padok.cloud/relevant-commit: cb9f15b90861c8c4364cdde63d17837c7a9ccca9
+    webhook.terraform.padok.cloud/branch-commit: cb9f15b90861c8c4364cdde63d17837c7a9ccca9
 spec:
   branch: main
   path: shared-path/
@@ -178,7 +178,7 @@ metadata:
     runner.terraform.padok.cloud/apply-commit: ca9b6c80ac8fb5cd837ae9b374b79ff33f472558
     runner.terraform.padok.cloud/apply-date: Mon May  8 10:21:53 UTC 2023
     runner.terraform.padok.cloud/apply-sum: AuP6pMNxWsbSZKnxZvxD842wy0qaF9JCX8HW1nFeL1I=
-    webhook.terraform.padok.cloud/relevant-commit: cb9f15b90861c8c4364cdde63d17837c7a9ccca9
+    webhook.terraform.padok.cloud/branch-commit: cb9f15b90861c8c4364cdde63d17837c7a9ccca9
 spec:
   branch: main
   path: nominal-case-six/
@@ -202,7 +202,7 @@ metadata:
   name: nominal-case-7
   namespace: default
   annotations:
-    webhook.terraform.padok.cloud/relevant-commit: cb9f15b90861c8c4364cdde63d17837c7a9ccca9
+    webhook.terraform.padok.cloud/branch-commit: cb9f15b90861c8c4364cdde63d17837c7a9ccca9
 spec:
   branch: main
   path: nominal-case-seven/
@@ -229,7 +229,7 @@ metadata:
     app.kubernetes.io/instance: in-cluster-burrito
   annotations:
     api.terraform.padok.cloud/sync-now: "true"
-    webhook.terraform.padok.cloud/relevant-commit: cb9f15b90861c8c4364cdde63d17837c7a9ccca9
+    webhook.terraform.padok.cloud/branch-commit: cb9f15b90861c8c4364cdde63d17837c7a9ccca9
   name: nominal-case-8
   namespace: default
 spec:

--- a/internal/controllers/terraformlayer/testdata/sync-window-case.yaml
+++ b/internal/controllers/terraformlayer/testdata/sync-window-case.yaml
@@ -25,7 +25,7 @@ metadata:
     runner.terraform.padok.cloud/plan-date: Mon May  8 11:21:53 UTC 2023
     runner.terraform.padok.cloud/plan-run: run-succeeded/0
     runner.terraform.padok.cloud/plan-sum: AuP6pMNxWsbSZKnxZvxD842wy0qaF9JCX8HW1nFeL1I=
-    webhook.terraform.padok.cloud/relevant-commit: cb9f15b90861c8c4364cdde63d17837c7a9ccca9
+    webhook.terraform.padok.cloud/branch-commit: cb9f15b90861c8c4364cdde63d17837c7a9ccca9
 spec:
   branch: main
   path: sync-window-case-one/
@@ -69,7 +69,7 @@ metadata:
     runner.terraform.padok.cloud/plan-date: Mon May  8 11:21:53 UTC 2023
     runner.terraform.padok.cloud/plan-run: run-succeeded/0
     runner.terraform.padok.cloud/plan-sum: AuP6pMNxWsbSZKnxZvxD842wy0qaF9JCX8HW1nFeL1I=
-    webhook.terraform.padok.cloud/relevant-commit: cb9f15b90861c8c4364cdde63d17837c7a9ccca9
+    webhook.terraform.padok.cloud/branch-commit: cb9f15b90861c8c4364cdde63d17837c7a9ccca9
 spec:
   branch: main
   path: sync-window-case-one/
@@ -109,7 +109,7 @@ metadata:
   name: sync-window-case-deny-plan-1
   namespace: default
   annotations:
-    webhook.terraform.padok.cloud/relevant-commit: cb9f15b90861c8c4364cdde63d17837c7a9ccca9
+    webhook.terraform.padok.cloud/branch-commit: cb9f15b90861c8c4364cdde63d17837c7a9ccca9
 spec:
   branch: main
   path: sync-window-case-one/
@@ -132,7 +132,7 @@ metadata:
   name: sync-window-repo-allow-plan
   namespace: default
   annotations:
-    webhook.terraform.padok.cloud/relevant-commit: cb9f15b90861c8c4364cdde63d17837c7a9ccca9
+    webhook.terraform.padok.cloud/branch-commit: cb9f15b90861c8c4364cdde63d17837c7a9ccca9
 spec:
   repository:
     url: git@github.com:padok-team/burrito-examples.git
@@ -151,7 +151,7 @@ metadata:
   name: sync-window-case-allow-plan-1
   namespace: default
   annotations:
-    webhook.terraform.padok.cloud/relevant-commit: cb9f15b90861c8c4364cdde63d17837c7a9ccca9
+    webhook.terraform.padok.cloud/branch-commit: cb9f15b90861c8c4364cdde63d17837c7a9ccca9
 spec:
   branch: main
   path: sync-window-case-one/
@@ -189,7 +189,7 @@ metadata:
     runner.terraform.padok.cloud/plan-date: Mon May  8 11:21:53 UTC 2023
     runner.terraform.padok.cloud/plan-run: run-succeeded/0
     runner.terraform.padok.cloud/plan-sum: AuP6pMNxWsbSZKnxZvxD842wy0qaF9JCX8HW1nFeL1I=
-    webhook.terraform.padok.cloud/relevant-commit: cb9f15b90861c8c4364cdde63d17837c7a9ccca9
+    webhook.terraform.padok.cloud/branch-commit: cb9f15b90861c8c4364cdde63d17837c7a9ccca9
 spec:
   branch: main
   path: sync-window-case-one/

--- a/internal/controllers/terraformlayer/testdata/unknown-cases.yaml
+++ b/internal/controllers/terraformlayer/testdata/unknown-cases.yaml
@@ -5,7 +5,7 @@ metadata:
   name: non-existent-repository
   namespace: default
   annotations:
-    webhook.terraform.padok.cloud/relevant-commit: cb9f15b90861c8c4364cdde63d17837c7a9ccca9
+    webhook.terraform.padok.cloud/branch-commit: cb9f15b90861c8c4364cdde63d17837c7a9ccca9
 spec:
   branch: main
   path: nominal-case-one/
@@ -28,7 +28,7 @@ metadata:
   name: last-run-not-exist
   namespace: default
   annotations:
-    webhook.terraform.padok.cloud/relevant-commit: cb9f15b90861c8c4364cdde63d17837c7a9ccca9
+    webhook.terraform.padok.cloud/branch-commit: cb9f15b90861c8c4364cdde63d17837c7a9ccca9
 spec:
   branch: main
   path: last-run-not-exist/


### PR DESCRIPTION
## Problem

`LastRelevantCommit` is currently used to launch runner pods when a layer ends in the PlanNeeded or ApplyNeeded state. But, as described in #946, the LastRelevantCommit may be an old, outdated commit, whose bundle has expired in the datastore (if a S3 lifecycle policy is configured).

In that case, manual syncs as well as automated drift detection may fail because it runs on the LastRelevantCommit exclusively:

https://github.com/padok-team/burrito/blob/68f576a4af9238ee5f68779e8ea1f1bf5d307038/internal/controllers/terraformlayer/states.go#L73-L78


## Solution

Use `LastBranchCommit` for Plan and Apply operations. The `LastRelevantCommit` is only used for computing conditions, to determine if changes have affected the layer, runner pods are launched on `LastBranchCommit` to always run on fresh updated code.

Fixes #946 