### PR TITLE
fix(api): replace runner list overrides

### DIFF
--- a/api/v1alpha1/common.go
+++ b/api/v1alpha1/common.go
@@ -184,63 +184,22 @@ func ChooseSlice(a, b []string) []string {
 }
 
 func mergeImagePullSecrets(a, b []corev1.LocalObjectReference) []corev1.LocalObjectReference {
-	result := []corev1.LocalObjectReference{}
-	temp := map[string]string{}
+	result := b
 
-	for _, elt := range a {
-		temp[elt.Name] = ""
-	}
-	for _, elt := range b {
-		temp[elt.Name] = ""
+	if len(result) == 0 {
+		result = a
 	}
 
-	for k := range temp {
-		result = append(result, corev1.LocalObjectReference{Name: k})
-	}
 	return result
 }
 
 func mergeEnvFrom(a, b []corev1.EnvFromSource) []corev1.EnvFromSource {
-	result := []corev1.EnvFromSource{}
-	tempSecret := map[string]string{}
-	tempConfigMap := map[string]string{}
+	result := b
 
-	for _, elt := range a {
-		if elt.ConfigMapRef != nil {
-			tempConfigMap[elt.ConfigMapRef.LocalObjectReference.Name] = elt.Prefix
-		} else {
-			tempSecret[elt.SecretRef.LocalObjectReference.Name] = elt.Prefix
-		}
-	}
-	for _, elt := range b {
-		if elt.ConfigMapRef != nil {
-			tempConfigMap[elt.ConfigMapRef.LocalObjectReference.Name] = elt.Prefix
-		} else {
-			tempSecret[elt.SecretRef.LocalObjectReference.Name] = elt.Prefix
-		}
+	if len(result) == 0 {
+		result = a
 	}
 
-	for k, v := range tempConfigMap {
-		result = append(result, corev1.EnvFromSource{
-			Prefix: v,
-			ConfigMapRef: &corev1.ConfigMapEnvSource{
-				LocalObjectReference: corev1.LocalObjectReference{
-					Name: k,
-				},
-			},
-		})
-	}
-
-	for k, v := range tempSecret {
-		result = append(result, corev1.EnvFromSource{
-			Prefix: v,
-			SecretRef: &corev1.SecretEnvSource{
-				LocalObjectReference: corev1.LocalObjectReference{
-					Name: k,
-				},
-			},
-		})
-	}
 	return result
 }
 
@@ -264,41 +223,22 @@ func mergeResourceList(a, b corev1.ResourceList) map[corev1.ResourceName]resourc
 }
 
 func mergeVolumeMounts(a, b []corev1.VolumeMount) []corev1.VolumeMount {
-	result := []corev1.VolumeMount{}
-	// Track which volume names are overridden by layer (b)
-	overriddenNames := make(map[string]bool)
+	result := b
 
-	// Collect all volume names from layer (b)
-	for _, elt := range b {
-		overriddenNames[elt.Name] = true
+	if len(result) == 0 {
+		result = a
 	}
 
-	// Add volume mounts from repo (a) that are not overridden
-	for _, elt := range a {
-		if !overriddenNames[elt.Name] {
-			result = append(result, elt)
-		}
-	}
-
-	// Add all volume mounts from layer (b)
-	result = append(result, b...)
 	return result
 }
 
 func mergeVolumes(a, b []corev1.Volume) []corev1.Volume {
-	result := []corev1.Volume{}
-	tempMap := map[string]corev1.Volume{}
+	result := b
 
-	for _, elt := range a {
-		tempMap[elt.Name] = elt
-	}
-	for _, elt := range b {
-		tempMap[elt.Name] = elt
+	if len(result) == 0 {
+		result = a
 	}
 
-	for _, v := range tempMap {
-		result = append(result, v)
-	}
 	return result
 }
 
@@ -351,18 +291,11 @@ func overrideExtraArgs(a, b ExtraArgs) ExtraArgs {
 }
 
 func MergeInitContainers(a, b []corev1.Container) []corev1.Container {
-	result := []corev1.Container{}
-	tempMap := map[string]corev1.Container{}
+	result := b
 
-	for _, elt := range a {
-		tempMap[elt.Name] = elt
-	}
-	for _, elt := range b {
-		tempMap[elt.Name] = elt
+	if len(result) == 0 {
+		result = a
 	}
 
-	for _, v := range tempMap {
-		result = append(result, v)
-	}
 	return result
 }

--- a/api/v1alpha1/common.go
+++ b/api/v1alpha1/common.go
@@ -177,7 +177,7 @@ func chooseInt(a, b *int, d int) *int {
 }
 
 func ChooseSlice(a, b []string) []string {
-	if len(b) > 0 {
+	if b != nil {
 		return b
 	}
 	return a
@@ -186,7 +186,7 @@ func ChooseSlice(a, b []string) []string {
 func mergeImagePullSecrets(a, b []corev1.LocalObjectReference) []corev1.LocalObjectReference {
 	result := b
 
-	if len(result) == 0 {
+	if result == nil {
 		result = a
 	}
 
@@ -196,7 +196,7 @@ func mergeImagePullSecrets(a, b []corev1.LocalObjectReference) []corev1.LocalObj
 func mergeEnvFrom(a, b []corev1.EnvFromSource) []corev1.EnvFromSource {
 	result := b
 
-	if len(result) == 0 {
+	if result == nil {
 		result = a
 	}
 
@@ -225,7 +225,7 @@ func mergeResourceList(a, b corev1.ResourceList) map[corev1.ResourceName]resourc
 func mergeVolumeMounts(a, b []corev1.VolumeMount) []corev1.VolumeMount {
 	result := b
 
-	if len(result) == 0 {
+	if result == nil {
 		result = a
 	}
 
@@ -235,7 +235,7 @@ func mergeVolumeMounts(a, b []corev1.VolumeMount) []corev1.VolumeMount {
 func mergeVolumes(a, b []corev1.Volume) []corev1.Volume {
 	result := b
 
-	if len(result) == 0 {
+	if result == nil {
 		result = a
 	}
 
@@ -245,7 +245,7 @@ func mergeVolumes(a, b []corev1.Volume) []corev1.Volume {
 func overrideTolerations(a, b []corev1.Toleration) []corev1.Toleration {
 	result := b
 
-	if len(result) == 0 {
+	if result == nil {
 		result = a
 	}
 
@@ -262,7 +262,7 @@ func overrideAffinity(repoAffinity, layerAffinity *corev1.Affinity) *corev1.Affi
 func mergeEnvVars(a, b []corev1.EnvVar) []corev1.EnvVar {
 	result := b
 
-	if len(result) == 0 {
+	if result == nil {
 		result = a
 	}
 
@@ -283,7 +283,7 @@ func mergeMaps(a, b map[string]string) map[string]string {
 func overrideExtraArgs(a, b ExtraArgs) ExtraArgs {
 	result := b
 
-	if len(result) == 0 {
+	if result == nil {
 		result = a
 	}
 
@@ -293,7 +293,7 @@ func overrideExtraArgs(a, b ExtraArgs) ExtraArgs {
 func MergeInitContainers(a, b []corev1.Container) []corev1.Container {
 	result := b
 
-	if len(result) == 0 {
+	if result == nil {
 		result = a
 	}
 

--- a/api/v1alpha1/common_test.go
+++ b/api/v1alpha1/common_test.go
@@ -882,6 +882,46 @@ func TestOverrideRunnerSpec(t *testing.T) {
 			configv1alpha1.OverrideRunnerSpec{},
 		},
 		{
+			"ExplicitEmptyLayerListsClearRepositoryLists",
+			&configv1alpha1.TerraformRepository{
+				Spec: configv1alpha1.TerraformRepositorySpec{
+					OverrideRunnerSpec: configv1alpha1.OverrideRunnerSpec{
+						ImagePullSecrets: []corev1.LocalObjectReference{{Name: "repo-secret"}},
+						Tolerations:      []corev1.Toleration{{Key: "repo-toleration"}},
+						Env:              []corev1.EnvVar{{Name: "REPO_ENV"}},
+						EnvFrom:          []corev1.EnvFromSource{{Prefix: "REPO_"}},
+						Volumes:          []corev1.Volume{{Name: "repo-volume"}},
+						VolumeMounts:     []corev1.VolumeMount{{Name: "repo-volume"}},
+						InitContainers:   []corev1.Container{{Name: "repo-init"}},
+						Command:          []string{"repo-command"},
+						Args:             []string{"repo-arg"},
+						ExtraInitArgs:    configv1alpha1.ExtraArgs{"repo-init-arg"},
+						ExtraPlanArgs:    configv1alpha1.ExtraArgs{"repo-plan-arg"},
+						ExtraApplyArgs:   configv1alpha1.ExtraArgs{"repo-apply-arg"},
+					},
+				},
+			},
+			&configv1alpha1.TerraformLayer{
+				Spec: configv1alpha1.TerraformLayerSpec{
+					OverrideRunnerSpec: configv1alpha1.OverrideRunnerSpec{
+						ImagePullSecrets: []corev1.LocalObjectReference{},
+						Tolerations:      []corev1.Toleration{},
+						Env:              []corev1.EnvVar{},
+						EnvFrom:          []corev1.EnvFromSource{},
+						Volumes:          []corev1.Volume{},
+						VolumeMounts:     []corev1.VolumeMount{},
+						InitContainers:   []corev1.Container{},
+						Command:          []string{},
+						Args:             []string{},
+						ExtraInitArgs:    configv1alpha1.ExtraArgs{},
+						ExtraPlanArgs:    configv1alpha1.ExtraArgs{},
+						ExtraApplyArgs:   configv1alpha1.ExtraArgs{},
+					},
+				},
+			},
+			configv1alpha1.OverrideRunnerSpec{},
+		},
+		{
 			"ChooseRepositoryImage",
 			&configv1alpha1.TerraformRepository{
 				Spec: configv1alpha1.TerraformRepositorySpec{
@@ -2129,7 +2169,7 @@ func TestMergeInitContainers(t *testing.T) {
 					Command: []string{"echo", "from-repo"},
 				},
 			},
-			[]corev1.Container{},
+			nil,
 			[]corev1.Container{
 				{
 					Name:    "repo-container",
@@ -2289,7 +2329,7 @@ func TestChooseSlice(t *testing.T) {
 		{
 			"OnlySliceA",
 			[]string{"value1", "value2"},
-			[]string{},
+			nil,
 			[]string{"value1", "value2"},
 		},
 		{
@@ -2305,10 +2345,10 @@ func TestChooseSlice(t *testing.T) {
 			[]string{"value3", "value4"},
 		},
 		{
-			"SliceAWithValues_SliceBEmpty",
+			"ExplicitEmptySliceB",
 			[]string{"value1", "value2"},
 			[]string{},
-			[]string{"value1", "value2"},
+			[]string{},
 		},
 		{
 			"SliceAEmpty_SliceBWithValues",

--- a/api/v1alpha1/common_test.go
+++ b/api/v1alpha1/common_test.go
@@ -4,6 +4,8 @@ import (
 	"reflect"
 	"testing"
 
+	"github.com/google/go-cmp/cmp"
+	"github.com/google/go-cmp/cmp/cmpopts"
 	corev1 "k8s.io/api/core/v1"
 	resource "k8s.io/apimachinery/pkg/api/resource"
 
@@ -987,9 +989,8 @@ func TestOverrideRunnerSpec(t *testing.T) {
 			},
 			configv1alpha1.OverrideRunnerSpec{
 				ImagePullSecrets: []corev1.LocalObjectReference{
-					{Name: "repo"},
-					{Name: "common"},
 					{Name: "layer"},
+					{Name: "common"},
 				},
 			},
 		},
@@ -1537,16 +1538,6 @@ func TestOverrideRunnerSpec(t *testing.T) {
 				EnvFrom: []corev1.EnvFromSource{
 					{
 						ConfigMapRef: &corev1.ConfigMapEnvSource{
-							LocalObjectReference: corev1.LocalObjectReference{Name: "repo-cm"},
-						},
-					},
-					{
-						SecretRef: &corev1.SecretEnvSource{
-							LocalObjectReference: corev1.LocalObjectReference{Name: "repo-secret"},
-						},
-					},
-					{
-						ConfigMapRef: &corev1.ConfigMapEnvSource{
 							LocalObjectReference: corev1.LocalObjectReference{Name: "layer-cm"},
 						},
 					},
@@ -1642,7 +1633,7 @@ func TestOverrideRunnerSpec(t *testing.T) {
 			},
 			configv1alpha1.OverrideRunnerSpec{
 				Volumes: []corev1.Volume{
-					{Name: "only-repo"},
+					{Name: "only-layer"},
 					{
 						Name: "both",
 						VolumeSource: corev1.VolumeSource{
@@ -1651,7 +1642,6 @@ func TestOverrideRunnerSpec(t *testing.T) {
 							},
 						},
 					},
-					{Name: "only-layer"},
 				},
 			},
 		},
@@ -1726,7 +1716,6 @@ func TestOverrideRunnerSpec(t *testing.T) {
 						Name:      "both",
 						MountPath: "/layer/path",
 					},
-					{Name: "only-repo"},
 				},
 			},
 		},
@@ -1759,7 +1748,6 @@ func TestOverrideRunnerSpec(t *testing.T) {
 			},
 			configv1alpha1.OverrideRunnerSpec{
 				VolumeMounts: []corev1.VolumeMount{
-					{Name: "only-repo"},
 					{
 						Name:      "only-layer",
 						MountPath: "/layer/path1",
@@ -2041,174 +2029,8 @@ func TestOverrideRunnerSpec(t *testing.T) {
 	for _, tc := range tt {
 		t.Run(tc.name, func(t *testing.T) {
 			result := configv1alpha1.GetOverrideRunnerSpec(tc.repository, tc.layer)
-
-			// Check Tolerations
-			if len(result.Tolerations) != len(tc.expectedSpec.Tolerations) {
-				t.Errorf("different tolerations size: got %d expected %d", len(result.Tolerations), len(tc.expectedSpec.Tolerations))
-			}
-			for i, tol := range result.Tolerations {
-				if tol.Key != result.Tolerations[i].Key {
-					t.Errorf("different tolerations key: got %s expected %s", result.Tolerations[i].Key, tol.Key)
-				}
-				if tol.Value != result.Tolerations[i].Value {
-					t.Errorf("different tolerations value: got %s expected %s", result.Tolerations[i].Value, tol.Value)
-				}
-				if tol.Effect != result.Tolerations[i].Effect {
-					t.Errorf("different tolerations effect: got %s expected %s", result.Tolerations[i].Effect, tol.Effect)
-				}
-			}
-
-			// Check Image
-			if tc.expectedSpec.Image != result.Image {
-				t.Errorf("different images: got %s expect %s", result.Image, tc.expectedSpec.Image)
-			}
-
-			// Check ImagePullSecrets
-			if len(result.ImagePullSecrets) != len(tc.expectedSpec.ImagePullSecrets) {
-				t.Errorf("differents image pull secrets size: got %d expected %d", len(result.ImagePullSecrets), len(tc.expectedSpec.ImagePullSecrets))
-			}
-			for _, secret := range result.ImagePullSecrets {
-				found := false
-				for _, expected := range tc.expectedSpec.ImagePullSecrets {
-					if secret.Name == expected.Name {
-						found = true
-					}
-				}
-				if !found {
-					t.Errorf("image pull secret %s not found in expected list %v", secret.Name, tc.expectedSpec.ImagePullSecrets)
-				}
-			}
-
-			//Check NodeSelector
-			if len(tc.expectedSpec.NodeSelector) != len(result.NodeSelector) {
-				t.Errorf("different size of node selector: got %d expected %d", len(result.NodeSelector), len(tc.expectedSpec.NodeSelector))
-			}
-			for k, v := range result.NodeSelector {
-				if tc.expectedSpec.NodeSelector[k] != v {
-					t.Errorf("different node selector value for label %s: got %s expected %s", k, v, tc.expectedSpec.NodeSelector[k])
-				}
-			}
-
-			// Check ServiceAccountName
-			if tc.expectedSpec.ServiceAccountName != result.ServiceAccountName {
-				t.Errorf("different serivce account names: got %s expect %s", result.ServiceAccountName, tc.expectedSpec.ServiceAccountName)
-			}
-
-			// Check Resources
-			for k, v := range result.Resources.Limits {
-				if v != tc.expectedSpec.Resources.Limits[k] {
-					t.Errorf("different limit value for %s: got %v expected %v", k, v, tc.expectedSpec.Resources.Limits[k])
-				}
-			}
-			for k, v := range result.Resources.Requests {
-				if v != tc.expectedSpec.Resources.Requests[k] {
-					t.Errorf("different request value for %s: got %v expected %v", k, v, tc.expectedSpec.Resources.Requests[k])
-				}
-			}
-
-			// Check Env
-			if len(result.Env) != len(tc.expectedSpec.Env) {
-				t.Errorf("differents env size: got %d expected %d", len(result.Env), len(tc.expectedSpec.Env))
-			}
-			for _, expectedEnv := range tc.expectedSpec.Env {
-				found := false
-				for _, givenEnv := range result.Env {
-					if givenEnv.Name == expectedEnv.Name {
-						if expectedEnv.ValueFrom != nil {
-							if reflect.DeepEqual(givenEnv.ValueFrom, expectedEnv.ValueFrom) {
-								found = true
-							}
-						} else if givenEnv.Value == expectedEnv.Value {
-							found = true
-						}
-
-					}
-				}
-				if !found {
-					t.Errorf("env %v not found in given list %v", expectedEnv, result.Env)
-				}
-			}
-
-			// Check EnvFrom
-			if len(result.EnvFrom) != len(tc.expectedSpec.EnvFrom) {
-				t.Errorf("differents env from size: got %d expected %d", len(result.EnvFrom), len(tc.expectedSpec.EnvFrom))
-			}
-			for _, envFrom := range result.EnvFrom {
-				found := false
-				for _, expected := range tc.expectedSpec.EnvFrom {
-					// We use two different if statements because, if we don't there might ba a nil pointer dereference
-					if envFrom.ConfigMapRef != nil && expected.ConfigMapRef != nil {
-						if envFrom.ConfigMapRef.LocalObjectReference.Name == expected.ConfigMapRef.LocalObjectReference.Name {
-							found = true
-						}
-					}
-					if envFrom.SecretRef != nil && expected.SecretRef != nil {
-						if envFrom.SecretRef.LocalObjectReference.Name == expected.SecretRef.LocalObjectReference.Name {
-							found = true
-						}
-					}
-				}
-				if !found {
-					t.Errorf("env from %v not found in expected list %v", envFrom, tc.expectedSpec.EnvFrom)
-				}
-			}
-
-			// Check Volumes
-			if len(result.Volumes) != len(tc.expectedSpec.Volumes) {
-				t.Errorf("differents volumes size: got %d expected %d", len(result.Volumes), len(tc.expectedSpec.Volumes))
-			}
-			for _, vol := range result.Volumes {
-				found := false
-				for _, expected := range tc.expectedSpec.Volumes {
-					if vol.Name == expected.Name {
-						found = true
-					}
-				}
-				if !found {
-					t.Errorf("volume %v not found in expected list %v", vol, tc.expectedSpec.Volumes)
-				}
-			}
-
-			// Check VolumeMounts
-			if len(result.VolumeMounts) != len(tc.expectedSpec.VolumeMounts) {
-				t.Errorf("differents volume mounts size: got %d expected %d", len(result.VolumeMounts), len(tc.expectedSpec.VolumeMounts))
-			}
-			for _, vol := range result.VolumeMounts {
-				found := false
-				for _, expected := range tc.expectedSpec.VolumeMounts {
-					// We only check for MountPath as it is enough to validate that layer config overrides the repo one
-					if vol.Name == expected.Name && vol.MountPath == expected.MountPath {
-						found = true
-					}
-				}
-				if !found {
-					t.Errorf("volume mount %v not found in expected list %v", vol, tc.expectedSpec.VolumeMounts)
-				}
-			}
-
-			// Check Metadata.Annotations
-			if len(result.Metadata.Annotations) != len(tc.expectedSpec.Metadata.Annotations) {
-				t.Errorf("differents annotations size: got %d expected %d", len(result.Metadata.Annotations), len(tc.expectedSpec.Metadata.Annotations))
-			}
-			for k, v := range result.Metadata.Annotations {
-				if tc.expectedSpec.Metadata.Annotations[k] != v {
-					t.Errorf("different annotation value for key %s: expected %s got %s", k, tc.expectedSpec.Metadata.Annotations[k], v)
-				}
-			}
-
-			// Check Metadata.v
-			if len(result.Metadata.Labels) != len(tc.expectedSpec.Metadata.Labels) {
-				t.Errorf("differents labels size: got %d expected %d", len(result.Metadata.Labels), len(tc.expectedSpec.Metadata.Labels))
-			}
-			for k, v := range result.Metadata.Labels {
-				if tc.expectedSpec.Metadata.Labels[k] != v {
-					t.Errorf("different label value for key %s: expected %s got %s", k, tc.expectedSpec.Metadata.Labels[k], v)
-				}
-			}
-
-			// Check Affinity
-			if !reflect.DeepEqual(result.Affinity, tc.expectedSpec.Affinity) {
-				t.Errorf("different affinity: got %v expected %v", result.Affinity, tc.expectedSpec.Affinity)
+			if diff := cmp.Diff(tc.expectedSpec, result, cmpopts.EquateEmpty()); diff != "" {
+				t.Errorf("unexpected override runner spec (-want +got):\n%s", diff)
 			}
 		})
 	}
@@ -2335,7 +2157,7 @@ func TestMergeInitContainers(t *testing.T) {
 			},
 		},
 		{
-			"MergeDistinctContainers",
+			"OverrideRepositoryContainersWithLayer",
 			[]corev1.Container{
 				{
 					Name:    "repo-container",
@@ -2351,11 +2173,6 @@ func TestMergeInitContainers(t *testing.T) {
 				},
 			},
 			[]corev1.Container{
-				{
-					Name:    "repo-container",
-					Image:   "repo-image:latest",
-					Command: []string{"echo", "from-repo"},
-				},
 				{
 					Name:    "layer-container",
 					Image:   "layer-image:latest",
@@ -2427,9 +2244,9 @@ func TestMergeInitContainers(t *testing.T) {
 			},
 			[]corev1.Container{
 				{
-					Name:    "repo-only",
-					Image:   "repo-image:1.0",
-					Command: []string{"echo", "repo-only"},
+					Name:    "layer-only",
+					Image:   "layer-image:1.0",
+					Command: []string{"echo", "layer-only"},
 				},
 				{
 					Name:    "common-container",
@@ -2442,11 +2259,6 @@ func TestMergeInitContainers(t *testing.T) {
 						},
 					},
 				},
-				{
-					Name:    "layer-only",
-					Image:   "layer-image:1.0",
-					Command: []string{"echo", "layer-only"},
-				},
 			},
 		},
 	}
@@ -2454,46 +2266,8 @@ func TestMergeInitContainers(t *testing.T) {
 	for _, tc := range tt {
 		t.Run(tc.name, func(t *testing.T) {
 			result := configv1alpha1.MergeInitContainers(tc.repoContainers, tc.layerContainers)
-
-			// Check if the result has the expected number of containers
-			if len(result) != len(tc.expected) {
-				t.Errorf("expected %d containers but got %d", len(tc.expected), len(result))
-				return
-			}
-
-			// Create a map of expected containers by name for easier lookup
-			expectedMap := make(map[string]corev1.Container)
-			for _, c := range tc.expected {
-				expectedMap[c.Name] = c
-			}
-
-			// Check each result container against the expected one
-			for _, resultContainer := range result {
-				expectedContainer, exists := expectedMap[resultContainer.Name]
-				if !exists {
-					t.Errorf("unexpected container in result: %s", resultContainer.Name)
-					continue
-				}
-
-				// Check important fields
-				if resultContainer.Image != expectedContainer.Image {
-					t.Errorf("container %s: expected image %s but got %s",
-						resultContainer.Name, expectedContainer.Image, resultContainer.Image)
-				}
-
-				// Compare commands
-				if !reflect.DeepEqual(resultContainer.Command, expectedContainer.Command) {
-					t.Errorf("container %s: commands don't match: expected %v but got %v",
-						resultContainer.Name, expectedContainer.Command, resultContainer.Command)
-				}
-
-				// Compare environment variables if present
-				if len(expectedContainer.Env) > 0 || len(resultContainer.Env) > 0 {
-					if !reflect.DeepEqual(resultContainer.Env, expectedContainer.Env) {
-						t.Errorf("container %s: environment variables don't match: expected %v but got %v",
-							resultContainer.Name, expectedContainer.Env, resultContainer.Env)
-					}
-				}
+			if diff := cmp.Diff(tc.expected, result, cmpopts.EquateEmpty()); diff != "" {
+				t.Errorf("unexpected init containers (-want +got):\n%s", diff)
 			}
 		})
 	}


### PR DESCRIPTION
## Summary

- make all remaining `OverrideRunnerSpec` list fields use layer-level replacement instead of merging repository and layer values
- preserve repository lists when the layer does not provide an override
- strengthen regression tests with full ordered structure comparisons while treating nil and empty collections equivalently

Closes #420

## Validation

- `go test ./api/v1alpha1`
- `go vet ./...`
- `make test` (Kubernetes envtest 1.36.0 plus Azurite, MinIO, LocalStack, and fake GCS Docker services; cleanup completed)
- `git diff --check`

## AI assistance disclosure

I used OpenAI Codex to help analyze the issue, implement the change, and update the regression tests. I reviewed the resulting diff and ran the validation commands listed above.