### PR TITLE
fix(docker): add libc6-compat for glibc compatibility

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -72,7 +72,7 @@ FROM docker.io/library/alpine:3.24.1@sha256:28bd5fe8b56d1bd048e5babf5b10710ebe0b
 WORKDIR /home/burrito
 
 # Install required packages
-RUN apk add --update --no-cache bash libc6-compat git openssh
+RUN apk add --update --no-cache bash git libc6-compat openssh
 
 ENV UID=65532
 ENV GID=65532

--- a/Dockerfile
+++ b/Dockerfile
@@ -72,7 +72,7 @@ FROM docker.io/library/alpine:3.24.1@sha256:28bd5fe8b56d1bd048e5babf5b10710ebe0b
 WORKDIR /home/burrito
 
 # Install required packages
-RUN apk add --update --no-cache git bash openssh
+RUN apk add --update --no-cache bash libc6-compat git openssh
 
 ENV UID=65532
 ENV GID=65532


### PR DESCRIPTION
### Summary
Adds `libc6-compat` to the final Alpine image stage in the `Dockerfile`.

### Problem
Certain third-party CLI tools or custom Terraform providers used by the Burrito runner are compiled against `glibc` instead of Alpine's native `musl`. Without `libc6-compat`, these binaries fail to execute inside the runner container with permission or missing library errors.

### Solution
Install `libc6-compat` via `apk` in the runner base image.

### Impact
- Improves out-of-the-box compatibility for `glibc` binaries.
- Negligible image size impact (< 50 KB).
- No breaking changes.