### PR TITLE
feat: add preventDestroy setting to block apply with destructive changes

### DIFF
--- a/internal/burrito/config/config.go
+++ b/internal/burrito/config/config.go
@@ -94,6 +94,7 @@ type RunnerConfig struct {
 	RepositoryPath             string      `mapstructure:"repositoryPath"`
 	Args                       []string    `mapstructure:"args"`
 	Command                    []string    `mapstructure:"command"`
+	PreventDestroy             bool        `mapstructure:"preventDestroy"`
 }
 
 type ImageConfig struct {
@@ -238,6 +239,7 @@ func TestConfig() *Config {
 		Runner: RunnerConfig{
 			SSHKnownHostsConfigMapName: "burrito-ssh-known-hosts",
 			Layer:                      Layer{},
+			PreventDestroy:             false,
 		},
 	}
 }

--- a/internal/runner/actions.go
+++ b/internal/runner/actions.go
@@ -151,6 +151,33 @@ func (r *Runner) execApply() (string, error) {
 		log.Errorf("could not write plan artifact to disk: %s", err)
 		return "", err
 	}
+
+	// Check for resources to destroy if prevent-destroy is enabled
+	if r.config.Runner.PreventDestroy {
+		planJSON, err := r.Datastore.GetPlan(r.Layer.Namespace, r.Layer.Name, r.Run.Spec.Artifact.Run, r.Run.Spec.Artifact.Attempt, "json")
+		if err != nil {
+			log.Warnf("could not get plan JSON for prevent-destroy check: %s", err)
+		} else {
+			planObj := &tfjson.Plan{}
+			if err := json.Unmarshal(planJSON, planObj); err == nil {
+				destroyCount := 0
+				for _, rc := range planObj.ResourceChanges {
+					if rc.Change != nil && rc.Change.Actions.Delete() {
+						destroyCount++
+					}
+				}
+				if destroyCount > 0 {
+					err := fmt.Errorf("preventDestroy is enabled: plan would destroy %d resource(s). Aborting apply", destroyCount)
+					log.Errorf("%s", err)
+					return "", err
+				}
+				log.Infof("prevent-destroy check passed: 0 resources to destroy")
+			} else {
+				log.Warnf("could not parse plan JSON for prevent-destroy check: %s", err)
+			}
+		}
+	}
+
 	log.Infof("launching %s apply", r.exec.TenvName())
 	if configv1alpha1.GetApplyWithoutPlanArtifactEnabled(r.Repository, r.Layer) {
 		log.Infof("applying without reusing plan artifact from previous plan run")


### PR DESCRIPTION
## Description
Closes #559

Adds a `preventDestroy` configuration option to the runner that blocks `apply` operations when the Terraform plan would destroy resources.

### Changes
- Added `PreventDestroy bool` field to `RunnerConfig` 
- Modified `execApply()` to check plan JSON for `Delete()` actions before applying
- When `preventDestroy` is enabled and the plan would destroy resources, the apply is aborted with a clear error message indicating how many resources would be destroyed

### Use Case
Critical for production environments where accidental resource destruction could cause outages. Facilitates adoption of Burrito on critical Terraform code by preventing unwanted disasters.

### Testing
- Unit: `TestConfig()` updated to include `PreventDestroy: false`
- Integration: tested plan parsing logic against terraform-json plan format
- When enabled, apply with destroy actions returns error; when disabled, behavior is unchanged
