### PR TITLE
feat: add Bitbucket provider (API, webhook, git auth)

### DIFF
--- a/internal/repository/credentials/credentials.go
+++ b/internal/repository/credentials/credentials.go
@@ -148,8 +148,9 @@ type Credential struct {
 	GitHubAppInstallationID string `json:"githubAppInstallationID,omitempty"`
 	GitHubAppPrivateKey     string `json:"githubAppPrivateKey,omitempty"`
 	// Token auth
-	GitHubToken string `json:"githubToken,omitempty"`
-	GitLabToken string `json:"gitlabToken,omitempty"`
+	GitHubToken      string `json:"githubToken,omitempty"`
+	GitLabToken      string `json:"gitlabToken,omitempty"`
+	BitbucketToken   string `json:"bitbucketToken,omitempty"`
 	// Repository URL
 	URL string `json:"url,omitempty"`
 	// Secret for webhook handling

--- a/internal/repository/providers/bitbucket/api.go
+++ b/internal/repository/providers/bitbucket/api.go
@@ -1,0 +1,150 @@
+package bitbucket
+
+import (
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"strings"
+
+	configv1alpha1 "github.com/padok-team/burrito/api/v1alpha1"
+	"github.com/padok-team/burrito/internal/controllers/terraformpullrequest/comment"
+	"github.com/padok-team/burrito/internal/repository/credentials"
+	log "github.com/sirupsen/logrus"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+type BitbucketClient struct {
+	username string
+	token    string
+	password string
+	baseURL  string
+}
+
+func (c *BitbucketClient) doRequest(method, path string, body io.Reader) (*http.Response, error) {
+	req, err := http.NewRequest(method, path, body)
+	if err != nil {
+		return nil, err
+	}
+	if c.token != "" {
+		req.SetBasicAuth(c.username, c.token)
+	} else {
+		req.SetBasicAuth(c.username, c.password)
+	}
+	req.Header.Set("Content-Type", "application/json")
+	return http.DefaultClient.Do(req)
+}
+
+type APIProvider struct {
+	config credentials.Credential
+	client *BitbucketClient
+}
+
+func (api *APIProvider) GetChanges(repository *configv1alpha1.TerraformRepository, pr *configv1alpha1.TerraformPullRequest) ([]string, error) {
+	workspace, repoSlug := getBitbucketNamespacedName(repository.Spec.Repository.Url)
+	url := fmt.Sprintf("https://api.bitbucket.org/2.0/repositories/%s/%s/pullrequests/%s/diffstat",
+		workspace, repoSlug, pr.Spec.ID)
+	resp, err := api.client.doRequest("GET", url, nil)
+	if err != nil {
+		log.Errorf("Error getting Bitbucket PR changes: %s", err)
+		return []string{}, err
+	}
+	defer resp.Body.Close()
+	var result struct {
+		Values []struct {
+			New struct {
+				Path string `json:"path"`
+			} `json:"new"`
+		} `json:"values"`
+	}
+	if err := json.NewDecoder(resp.Body).Decode(&result); err != nil {
+		return []string{}, err
+	}
+	var changes []string
+	for _, v := range result.Values {
+		changes = append(changes, v.New.Path)
+	}
+	return changes, nil
+}
+
+func (api *APIProvider) Comment(repository *configv1alpha1.TerraformRepository, pr *configv1alpha1.TerraformPullRequest, prComment comment.Comment) error {
+	body, err := prComment.Generate("")
+	if err != nil {
+		return err
+	}
+	body = comment.WithManagedMarker(body)
+	workspace, repoSlug := getBitbucketNamespacedName(repository.Spec.Repository.Url)
+	url := fmt.Sprintf("https://api.bitbucket.org/2.0/repositories/%s/%s/pullrequests/%s/comments",
+		workspace, repoSlug, pr.Spec.ID)
+	payload := map[string]interface{}{"content": map[string]interface{}{"raw": body}}
+	payloadBytes, _ := json.Marshal(payload)
+	resp, err := api.client.doRequest("POST", url, strings.NewReader(string(payloadBytes)))
+	if err != nil {
+		return err
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode >= 400 {
+		return fmt.Errorf("Bitbucket comment failed: %d", resp.StatusCode)
+	}
+	return nil
+}
+
+func (api *APIProvider) ListPullRequests(repository *configv1alpha1.TerraformRepository) ([]configv1alpha1.TerraformPullRequest, error) {
+	workspace, repoSlug := getBitbucketNamespacedName(repository.Spec.Repository.Url)
+	url := fmt.Sprintf("https://api.bitbucket.org/2.0/repositories/%s/%s/pullrequests?state=OPEN",
+		workspace, repoSlug)
+	resp, err := api.client.doRequest("GET", url, nil)
+	if err != nil {
+		return nil, err
+	}
+	defer resp.Body.Close()
+	var result struct {
+		Values []struct {
+			ID     int    `json:"id"`
+			Title  string `json:"title"`
+			Source struct {
+				Branch struct {
+					Name string `json:"name"`
+				} `json:"branch"`
+				Commit struct {
+					Hash string `json:"hash"`
+				} `json:"commit"`
+			} `json:"source"`
+			Destination struct {
+				Branch struct {
+					Name string `json:"name"`
+				} `json:"branch"`
+			} `json:"destination"`
+		} `json:"values"`
+	}
+	if err := json.NewDecoder(resp.Body).Decode(&result); err != nil {
+		return nil, err
+	}
+	var pullRequests []configv1alpha1.TerraformPullRequest
+	for _, pr := range result.Values {
+		pullRequests = append(pullRequests, configv1alpha1.TerraformPullRequest{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      fmt.Sprintf("%s-%d", repository.Name, pr.ID),
+				Namespace: repository.Namespace,
+			},
+			Spec: configv1alpha1.TerraformPullRequestSpec{
+				Branch: pr.Source.Branch.Name,
+				Base:   pr.Destination.Branch.Name,
+				ID:     fmt.Sprintf("%d", pr.ID),
+				Repository: configv1alpha1.TerraformLayerRepository{
+					Name:      repository.Name,
+					Namespace: repository.Namespace,
+				},
+			},
+		})
+	}
+	return pullRequests, nil
+}
+
+func getBitbucketNamespacedName(url string) (string, string) {
+	parts := strings.Split(strings.TrimPrefix(strings.TrimPrefix(url, "https://"), "bitbucket.org/"), "/")
+	if len(parts) >= 2 {
+		return parts[0], strings.TrimSuffix(parts[1], ".git")
+	}
+	return "", ""
+}

--- a/internal/repository/providers/bitbucket/bitbucket.go
+++ b/internal/repository/providers/bitbucket/bitbucket.go
@@ -1,0 +1,63 @@
+package bitbucket
+
+import (
+	"fmt"
+
+	"github.com/go-git/go-git/v5/plumbing/transport"
+	"github.com/go-git/go-git/v5/plumbing/transport/http"
+	configv1alpha1 "github.com/padok-team/burrito/api/v1alpha1"
+	"github.com/padok-team/burrito/internal/repository/credentials"
+	"github.com/padok-team/burrito/internal/repository/providers/standard"
+	"github.com/padok-team/burrito/internal/repository/types"
+)
+
+type Bitbucket struct {
+	Config credentials.Credential
+}
+
+func (b *Bitbucket) GetWebhookProvider() (types.WebhookProvider, error) {
+	return &WebhookProvider{}, nil
+}
+
+func (b *Bitbucket) GetAPIProvider() (types.APIProvider, error) {
+	client := buildBitbucketClient(b.Config)
+	return &APIProvider{
+		config: b.Config,
+		client: client,
+	}, nil
+}
+
+func (b *Bitbucket) GetGitProvider(repository *configv1alpha1.TerraformRepository) (types.GitProvider, error) {
+	auth, err := buildGitCredentials(b.Config)
+	if err != nil {
+		return nil, err
+	}
+	return &standard.GitProvider{
+		RepoURL:    repository.Spec.Repository.Url,
+		AuthMethod: auth,
+	}, nil
+}
+
+func buildBitbucketClient(config credentials.Credential) *BitbucketClient {
+	return &BitbucketClient{
+		username: config.Username,
+		token:    config.BitbucketToken,
+		password: config.Password,
+		baseURL:  config.URL,
+	}
+}
+
+func buildGitCredentials(config credentials.Credential) (transport.AuthMethod, error) {
+	if config.BitbucketToken != "" {
+		return &http.BasicAuth{
+			Username: "x-token-auth",
+			Password: config.BitbucketToken,
+		}, nil
+	} else if config.Username != "" && config.Password != "" {
+		return &http.BasicAuth{
+			Username: config.Username,
+			Password: config.Password,
+		}, nil
+	}
+	return nil, fmt.Errorf("no Bitbucket authentication method configured")
+}

--- a/internal/repository/providers/bitbucket/webhook.go
+++ b/internal/repository/providers/bitbucket/webhook.go
@@ -1,0 +1,92 @@
+package bitbucket
+
+import (
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"strings"
+
+	utils "github.com/padok-team/burrito/internal/utils/url"
+	"github.com/padok-team/burrito/internal/webhook/event"
+	log "github.com/sirupsen/logrus"
+)
+
+type WebhookProvider struct{}
+
+func (wp *WebhookProvider) ParseWebhookPayload(r *http.Request) (interface{}, bool) {
+	if r.Header.Get("X-Event-Key") == "" {
+		return nil, false
+	}
+	body, err := io.ReadAll(r.Body)
+	if err != nil {
+		log.Errorf("failed to read Bitbucket webhook body: %s", err)
+		return nil, false
+	}
+	var payload map[string]interface{}
+	if err := json.Unmarshal(body, &payload); err != nil {
+		return nil, false
+	}
+	return payload, true
+}
+
+func (wp *WebhookProvider) GetEventFromWebhookPayload(p interface{}) (event.Event, error) {
+	payload, ok := p.(map[string]interface{})
+	if !ok {
+		return nil, nil
+	}
+	eventKey, _ := payload["eventKey"].(string)
+
+	switch {
+	case eventKey == "repo:push" || eventKey == "push":
+		push, _ := payload["push"].(map[string]interface{})
+		changes := []string{}
+		if push != nil {
+			if ch, ok := push["changes"].([]interface{}); ok {
+				for _, c := range ch {
+					if cm, ok := c.(map[string]interface{}); ok {
+						if old, ok := cm["old"].(map[string]interface{}); ok {
+							if path, ok := old["path"].(string); ok {
+								changes = append(changes, path)
+							}
+						}
+					}
+				}
+			}
+		}
+		repo, _ := payload["repository"].(map[string]interface{})
+		links, _ := repo["links"].(map[string]interface{})
+		selfLink, _ := links["self"].(map[string]interface{})
+		href, _ := selfLink["href"].(string)
+		return &event.PushEvent{
+			URL:       utils.NormalizeUrl(href),
+			Reference: event.ParseReference("refs/heads/main"),
+			Changes:   changes,
+		}, nil
+
+	case strings.Contains(eventKey, "pullrequest"):
+		pr, _ := payload["pullrequest"].(map[string]interface{})
+		if pr == nil {
+			return nil, nil
+		}
+		id := fmt.Sprintf("%.0f", pr["id"].(float64))
+		source, _ := pr["source"].(map[string]interface{})
+		dest, _ := pr["destination"].(map[string]interface{})
+		sourceBranch, _ := source["branch"].(map[string]interface{})
+		destBranch, _ := dest["branch"].(map[string]interface{})
+		
+		action := event.PullRequestOpened
+		if strings.Contains(eventKey, "merged") || strings.Contains(eventKey, "declined") {
+			action = event.PullRequestClosed
+		}
+		
+		return &event.PullRequestEvent{
+			ID:        id,
+			URL:       utils.NormalizeUrl(""),
+			Reference: sourceBranch["name"].(string),
+			Action:    action,
+			Base:      destBranch["name"].(string),
+		}, nil
+	}
+	return nil, nil
+}

--- a/internal/repository/repository.go
+++ b/internal/repository/repository.go
@@ -5,6 +5,7 @@ import (
 
 	configv1alpha1 "github.com/padok-team/burrito/api/v1alpha1"
 	"github.com/padok-team/burrito/internal/repository/credentials"
+	"github.com/padok-team/burrito/internal/repository/providers/bitbucket"
 	"github.com/padok-team/burrito/internal/repository/providers/github"
 	"github.com/padok-team/burrito/internal/repository/providers/gitlab"
 	"github.com/padok-team/burrito/internal/repository/providers/mock"
@@ -46,6 +47,8 @@ func GetProviderFromCredentials(RepositoryCredentials credentials.Credential) (t
 		provider = &github.Github{Config: RepositoryCredentials}
 	case "gitlab":
 		provider = &gitlab.Gitlab{Config: RepositoryCredentials}
+	case "bitbucket":
+		provider = &bitbucket.Bitbucket{Config: RepositoryCredentials}
 	case "standard":
 		provider = &standard.Standard{Config: RepositoryCredentials}
 	case "mock":


### PR DESCRIPTION
## Description
Closes #442

Implements the Bitbucket provider for Burrito based on the provider interface structure used by GitHub and GitLab.

### Files Added
- `internal/repository/providers/bitbucket/bitbucket.go` — Provider implementation with webhook, API, and git auth
- `internal/repository/providers/bitbucket/api.go` — Bitbucket Cloud API integration (PR listing, comments, changes)
- `internal/repository/providers/bitbucket/webhook.go` — Webhook event parsing (push, pull request)

### Changes
- Added `BitbucketToken` field to `Credential` struct
- Registered `"bitbucket"` provider in `GetProviderFromCredentials()`
- Supports Bitbucket App Password and token-based authentication
- Git clone via BasicAuth (`x-token-auth` + token, or username + password)
- API: `ListPullRequests`, `GetChanges`, `Comment`
- Webhook: parses `repo:push` and `pullrequest:*` events

### Authentication
Set `provider: "bitbucket"` in your credentials with:
- `bitbucketToken` (recommended) or `username` + `password` (app password)
