### PR TITLE
fix(repository): synchronize credential store reads

### DIFF
--- a/internal/repository/credentials/credentials.go
+++ b/internal/repository/credentials/credentials.go
@@ -24,7 +24,7 @@ const (
 
 type CredentialStore struct {
 	TTL time.Duration
-	mu  sync.Mutex
+	mu  sync.RWMutex
 	client.Client
 	sharedCredentials     []*SharedCredential
 	repositoryCredentials []*RepositoryCredential
@@ -40,23 +40,40 @@ func NewCredentialStore(client client.Client, ttl time.Duration) *CredentialStor
 }
 
 func (s *CredentialStore) GetAllCredentials() ([]*SharedCredential, []*RepositoryCredential) {
-	if time.Since(s.lastUpdate) >= s.TTL {
-		err := s.updateCredentials()
-		if err != nil {
-			log.Errorf("Failed to update credentials: %v", err)
-		}
-	}
+	s.updateCredentialsIfNeeded()
+
+	// Keep reads synchronized with refresh writes while allowing concurrent readers.
+	s.mu.RLock()
+	defer s.mu.RUnlock()
 	return s.sharedCredentials, s.repositoryCredentials
+}
+
+func (s *CredentialStore) updateCredentialsIfNeeded() {
+	s.mu.RLock()
+	needsUpdate := time.Since(s.lastUpdate) >= s.TTL
+	s.mu.RUnlock()
+
+	if !needsUpdate {
+		return
+	}
+
+	// updateCredentials locks again and re-checks the TTL, so concurrent callers do not all refresh.
+	err := s.updateCredentials()
+	if err != nil {
+		log.Errorf("failed to update credentials: %v", err)
+	}
 }
 
 func (s *CredentialStore) updateCredentials() error {
 	s.mu.Lock()
 	defer s.mu.Unlock()
-	// Skip if the last update was less than the TTL
-	if time.Since(s.lastUpdate) < s.TTL {
-		return nil
+	if time.Since(s.lastUpdate) >= s.TTL {
+		return s.refreshCredentials()
 	}
+	return nil
+}
 
+func (s *CredentialStore) refreshCredentials() error {
 	sharedSecrets := &corev1.SecretList{}
 	err := s.List(context.Background(), sharedSecrets, client.MatchingFields{"type": SharedCredentialsType})
 	if err != nil {
@@ -99,12 +116,11 @@ func (s *CredentialStore) updateCredentials() error {
 // Returns the credentials for a given repository. If a specific repository credential is found, it will be returned.
 // If not, the most specific shared credential that matches the repository will be returned.
 func (s *CredentialStore) GetCredentials(repository *configv1alpha1.TerraformRepository) (*Credential, error) {
-	if time.Since(s.lastUpdate) >= s.TTL {
-		err := s.updateCredentials()
-		if err != nil {
-			log.Errorf("failed to update credentials: %v", err)
-		}
-	}
+	s.updateCredentialsIfNeeded()
+
+	// Keep iteration synchronized with refresh writes while allowing concurrent readers.
+	s.mu.RLock()
+	defer s.mu.RUnlock()
 	for _, repositoryCredentials := range s.repositoryCredentials {
 		if repositoryCredentials.Matches(repository) {
 			return &repositoryCredentials.Credential, nil

--- a/internal/repository/credentials/credentials_test.go
+++ b/internal/repository/credentials/credentials_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"path/filepath"
+	"sync"
 	"testing"
 	"time"
 
@@ -11,12 +12,17 @@ import (
 	. "github.com/onsi/gomega"
 
 	configv1alpha1 "github.com/padok-team/burrito/api/v1alpha1"
+	"github.com/padok-team/burrito/internal/annotations"
 	"github.com/padok-team/burrito/internal/repository/credentials"
 	utils "github.com/padok-team/burrito/internal/testing"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/client-go/kubernetes/scheme"
 	"k8s.io/client-go/rest"
 	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 	"sigs.k8s.io/controller-runtime/pkg/envtest"
 	logf "sigs.k8s.io/controller-runtime/pkg/log"
 	"sigs.k8s.io/controller-runtime/pkg/log/zap"
@@ -31,6 +37,90 @@ func TestCredentials(t *testing.T) {
 	RegisterFailHandler(Fail)
 
 	RunSpecs(t, "Credentials Suite")
+}
+
+func TestCredentialStoreConcurrentGetters(t *testing.T) {
+	scheme := runtime.NewScheme()
+	if err := corev1.AddToScheme(scheme); err != nil {
+		t.Fatalf("add corev1 to scheme: %v", err)
+	}
+
+	repository := &configv1alpha1.TerraformRepository{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "repo",
+			Namespace: "default",
+		},
+		Spec: configv1alpha1.TerraformRepositorySpec{
+			Repository: configv1alpha1.TerraformRepositoryRepository{
+				Url: "https://github.com/padok-team/burrito",
+			},
+		},
+	}
+	repositorySecret := &corev1.Secret{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "repo-creds",
+			Namespace: "default",
+		},
+		Type: corev1.SecretType(credentials.CredentialsType),
+		Data: map[string][]byte{
+			"provider": []byte("github"),
+			"url":      []byte("https://github.com/padok-team/burrito"),
+			"username": []byte("repository-user"),
+			"password": []byte("repository-password"),
+		},
+	}
+	sharedSecret := &corev1.Secret{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "shared-creds",
+			Namespace: "default",
+			Annotations: map[string]string{
+				annotations.AllowedTenants: "default",
+			},
+		},
+		Type: corev1.SecretType(credentials.SharedCredentialsType),
+		Data: map[string][]byte{
+			"provider": []byte("github"),
+			"url":      []byte("https://github.com/padok-team"),
+			"username": []byte("shared-user"),
+			"password": []byte("shared-password"),
+		},
+	}
+
+	client := fake.NewClientBuilder().
+		WithScheme(scheme).
+		WithObjects(repositorySecret, sharedSecret).
+		WithIndex(&corev1.Secret{}, "type", func(obj client.Object) []string {
+			return []string{string(obj.(*corev1.Secret).Type)}
+		}).
+		Build()
+	store := credentials.NewCredentialStore(client, 0)
+
+	var wg sync.WaitGroup
+	for i := 0; i < 32; i++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			for j := 0; j < 100; j++ {
+				if _, err := store.GetCredentials(repository); err != nil {
+					t.Errorf("GetCredentials returned error: %v", err)
+					return
+				}
+			}
+		}()
+
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			for j := 0; j < 100; j++ {
+				shared, repository := store.GetAllCredentials()
+				if len(shared) != 1 || len(repository) != 1 {
+					t.Errorf("GetAllCredentials returned %d shared and %d repository credentials", len(shared), len(repository))
+					return
+				}
+			}
+		}()
+	}
+	wg.Wait()
 }
 
 var _ = BeforeSuite(func() {


### PR DESCRIPTION
## Summary

Fix #963 

`updateCredentials()` already used `s.mu` when refreshing `lastUpdate`, `sharedCredentials`, and `repositoryCredentials`, but `GetCredentials()` and `GetAllCredentials()` read those same fields without locking. Concurrent webhook requests or reconcile paths could therefore read the cache while another goroutine refreshed it.

This PR:

- synchronizes the getter read paths with the existing mutex
- keeps the refresh path double-checked under lock
- adds a focused race regression test for concurrent `GetCredentials()` / `GetAllCredentials()` calls

## Race Repro On Old Code

The race is visible when the credential store paths are exercised concurrently:

```bash
go test -race ./internal/repository/credentials -run TestCredentialStoreConcurrentGetters -count=1
```

On the old implementation, that fails with:

```text
WARNING: DATA RACE
Write at ...:
  github.com/padok-team/burrito/internal/repository/credentials.(*CredentialStore).updateCredentials()
      internal/repository/credentials/credentials.go:94
  github.com/padok-team/burrito/internal/repository/credentials.(*CredentialStore).GetCredentials()
      internal/repository/credentials/credentials.go:103

Previous read at ...:
  github.com/padok-team/burrito/internal/repository/credentials.(*CredentialStore).GetCredentials()
      internal/repository/credentials/credentials.go:102
```

It also reports `updateCredentials()` racing with `GetAllCredentials()` reads:

```text
Write:
  (*CredentialStore).updateCredentials()
      internal/repository/credentials/credentials.go:92

Previous read:
  (*CredentialStore).GetAllCredentials()
      internal/repository/credentials/credentials.go:49
```

Final result on old code:

```text
--- FAIL: TestCredentialStoreConcurrentGetters
    testing.go:1712: race detected during execution of test
FAIL
```

## Testing

```bash
go test ./internal/repository/credentials -run TestCredentialStoreConcurrentGetters -count=1
go test -race ./internal/repository/credentials -run TestCredentialStoreConcurrentGetters -count=1
```

All passed.

