### PR TITLE
docs: fix indefinite article before SSH in private-modules guide

### DIFF
--- a/docs/user-guide/private-modules.md
+++ b/docs/user-guide/private-modules.md
@@ -81,7 +81,7 @@ spec:
 
 ## The layer uses a private module with SSH
 
-### 1. Create a Secret with a SSH private key which can pull the modules' repositories
+### 1. Create a Secret with an SSH private key which can pull the modules' repositories
 
 Create a Kubernetes Secret which looks like the following:
 


### PR DESCRIPTION
## Summary
- Fixes a small grammar slip in the private modules guide: \"a SSH private key\" -> \"an SSH private key\" (SSH is pronounced with a leading vowel sound, so it takes \"an\").

## Type of change
- Documentation-only fix, no functional/code changes.

## Test plan
- N/A (single-word grammar fix in a Markdown doc).