### PR TITLE
fix(ci): make the release pipeline autonomous and verifiable

### DIFF
--- a/.github/workflows/docs.yaml
+++ b/.github/workflows/docs.yaml
@@ -23,6 +23,11 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: write
+    # The release push runs this workflow twice, standalone and through
+    # tag-on-release.yaml. Both 'mike deploy --push' to gh-pages, so serialize them.
+    concurrency:
+      group: gh-pages-deploy
+      cancel-in-progress: false
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
         with:
@@ -53,7 +58,9 @@ jobs:
         run: uv run mike deploy --push --update-aliases unstable
 
       - name: Deploy pages (new release)
-        if: github.event_name == 'workflow_call'
+        # A reusable workflow inherits the event of its caller, so github.event_name is
+        # never 'workflow_call'. The release input is the only reliable signal here.
+        if: inputs.version != ''
         run: |
           uv run mike deploy --push --update-aliases ${{ inputs.version }} latest
           echo "Deployed version ${{ inputs.version }} to GitHub Pages"

--- a/.github/workflows/helm.yaml
+++ b/.github/workflows/helm.yaml
@@ -7,12 +7,6 @@ on:
         description: "Version to deploy (e.g. v1.2.3)"
         type: string
         required: true
-  workflow_dispatch:
-    inputs:
-      version:
-        description: "Version to release (e.g. v1.2.3)"
-        required: true
-        type: string
   push:
     branches:
       - main
@@ -61,16 +55,20 @@ jobs:
 
       - name: Compute versions
         shell: bash
+        env:
+          RELEASE_VERSION: ${{ inputs.version }}
         run: |
           CURRENT_VERSION=$(yq $CHART_PATH/Chart.yaml --expression .version)
-          if [[ ${{ github.event_name }} == 'pull_request' || ${{ github.event_name }} == 'push' && ${{ github.ref_type }} == 'branch' ]]; then
-            echo "VERSION=$(echo $CURRENT_VERSION-${{ github.sha }})" >> $GITHUB_ENV
-            echo "APP_VERSION=${{ github.sha }}" >> $GITHUB_ENV
-          elif [[ ${{ github.event_name }} == 'workflow_call' || ${{ github.event_name }} == 'workflow_dispatch' ]]; then
-            echo "VERSION=$(echo ${{ inputs.version }} | sed 's/^v//')" >> $GITHUB_ENV
-            echo "APP_VERSION=${{ inputs.version }}" >> $GITHUB_ENV
+          # A reusable workflow inherits the event of its caller, so github.event_name is
+          # never 'workflow_call'. The release input is the only reliable signal here.
+          if [[ -n "$RELEASE_VERSION" ]]; then
+            echo "VERSION=${RELEASE_VERSION#v}" >> $GITHUB_ENV
+            echo "APP_VERSION=$RELEASE_VERSION" >> $GITHUB_ENV
+          elif [[ "$GITHUB_EVENT_NAME" == 'pull_request' || "$GITHUB_EVENT_NAME" == 'push' ]]; then
+            echo "VERSION=$CURRENT_VERSION-$GITHUB_SHA" >> $GITHUB_ENV
+            echo "APP_VERSION=$GITHUB_SHA" >> $GITHUB_ENV
           else
-            echo "Unsupported event type"
+            echo "Unsupported event type: $GITHUB_EVENT_NAME"
             exit 1
           fi
 

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -9,7 +9,39 @@ on:
         type: string
 
 jobs:
+  guard:
+    name: Check release prerequisites
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+      # workflow_dispatch is open to anyone with write access, which includes the
+      # burrito-developers team. Cutting a release publishes a signed image, so it is
+      # restricted to the roles the burrito-maintainers team holds on this repository.
+      - name: Ensure the actor is a maintainer
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          ROLE=$(gh api "repos/$GITHUB_REPOSITORY/collaborators/$GITHUB_ACTOR/permission" --jq .role_name)
+          case "$ROLE" in
+            admin | maintain)
+              echo "$GITHUB_ACTOR holds the '$ROLE' role on this repository."
+              ;;
+            *)
+              echo "Only maintainers can cut a release, $GITHUB_ACTOR holds the '$ROLE' role."
+              exit 1
+              ;;
+          esac
+
+      - name: Ensure the workflow was dispatched on main
+        run: |
+          if [[ "$GITHUB_REF" != "refs/heads/main" ]]; then
+            echo "Releases must be dispatched on main, got $GITHUB_REF."
+            exit 1
+          fi
+
   build-and-push:
+    needs: guard
     uses: ./.github/workflows/build-and-push.yaml
     with:
       version: ${{ inputs.version }}
@@ -32,8 +64,8 @@ jobs:
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
         with:
           fetch-depth: 0
-          ref: main
-          persist-credentials: false
+          ref: ${{ github.sha }} # The exact commit the image was built from, main may have moved since
+          persist-credentials: true # The bump branch push below authenticates with them
 
       - name: Bump VERSION file
         run: echo "${{ inputs.version }}" > VERSION
@@ -54,12 +86,23 @@ jobs:
       - name: Commit and open PR
         env:
           GH_TOKEN: ${{ github.token }}
+          VERSION: ${{ inputs.version }}
         run: |
-          BRANCH_NAME="bump-version-${{ inputs.version }}"
+          BRANCH_NAME="bump-version-$VERSION"
           git config user.name "github-actions[bot]"
           git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
           git add .
-          git switch -c $BRANCH_NAME
-          git commit -m "chore(release): bump version to ${{ inputs.version }}"
-          git push origin $BRANCH_NAME
-          gh pr create --fill --base main --head $BRANCH_NAME
+          git switch -c "$BRANCH_NAME"
+          # The Source-SHA trailer ties the release commit to the source the signed
+          # image was built from. tag-on-release.yaml refuses to tag without it.
+          git commit -m "chore(release): bump version to $VERSION" -m "Source-SHA: $GITHUB_SHA"
+          git push origin "$BRANCH_NAME"
+          PR_URL=$(gh pr create --fill --base main --head "$BRANCH_NAME")
+
+          # Auto-merge still honours the branch ruleset, it only removes the wait. The
+          # squash message is set explicitly so the trailer survives the merge whatever
+          # the repository default is.
+          gh pr merge "$PR_URL" --auto --squash \
+            --subject "chore(release): bump version to $VERSION (#${PR_URL##*/})" \
+            --body "Source-SHA: $GITHUB_SHA" \
+            || echo "::warning::Could not enable auto-merge, is it allowed on the repository? Merge $PR_URL manually."

--- a/.github/workflows/tag-on-release.yaml
+++ b/.github/workflows/tag-on-release.yaml
@@ -26,7 +26,8 @@ jobs:
       - name: Checkout
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
         with:
-          persist-credentials: false
+          fetch-depth: 0 # Required to diff against the commit the image was built from
+          persist-credentials: true # The tag push below authenticates with them
 
       - name: Read version
         id: version
@@ -41,13 +42,58 @@ jobs:
             echo "exists=false" >> $GITHUB_OUTPUT
           fi
 
+      - name: Verify the release commit matches the built image source
+        if: steps.check.outputs.exists == 'false'
+        run: |
+          SOURCE_SHA=$(git log -1 --format=%B | sed -n 's/.*Source-SHA:[[:space:]]*\([0-9a-f]\{40\}\).*/\1/p' | head -1)
+          if [[ -z "$SOURCE_SHA" ]]; then
+            echo "No Source-SHA trailer found on the release commit."
+            echo "VERSION is only meant to be bumped by the Release workflow, which records"
+            echo "the commit the signed image was built from."
+            exit 1
+          fi
+
+          # main may have moved between the build and the merge of the bump PR: the
+          # signed image would then no longer match the source about to be tagged.
+          UNEXPECTED=$(git diff --name-only "$SOURCE_SHA" HEAD \
+            | grep -vxE "VERSION|${CHART_PATH#./}/Chart.yaml|${CHART_PATH#./}/values.yaml" || true)
+          if [[ -n "$UNEXPECTED" ]]; then
+            echo "The release commit diverges from $SOURCE_SHA outside of the release files:"
+            echo "$UNEXPECTED"
+            echo "Re-run the Release workflow to rebuild and re-sign from the current main."
+            exit 1
+          fi
+          echo "Release commit matches the image built from $SOURCE_SHA."
+
       - name: Create and push tag
         if: steps.check.outputs.exists == 'false'
+        env:
+          TAG: ${{ steps.version.outputs.value }}
+          MAX_ATTEMPTS: 45
+          RETRY_DELAY: 60
         run: |
           git config user.name "github-actions[bot]"
           git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
-          git tag "${{ steps.version.outputs.value }}"
-          git push origin "${{ steps.version.outputs.value }}"
+          git tag "$TAG"
+
+          # The 'releases' tag ruleset requires the status checks of this very commit to
+          # be green. They are triggered by the same push as this workflow, so the first
+          # attempts are expected to be rejected until they finish.
+          for attempt in $(seq 1 "$MAX_ATTEMPTS"); do
+            if output=$(git push origin "$TAG" 2>&1); then
+              echo "$output"
+              exit 0
+            fi
+            echo "$output"
+            if ! grep -q "GH013" <<< "$output"; then
+              echo "Push rejected for a reason unrelated to the tag ruleset, aborting."
+              exit 1
+            fi
+            echo "Required status checks are not green yet, retrying in ${RETRY_DELAY}s ($attempt/$MAX_ATTEMPTS)"
+            sleep "$RETRY_DELAY"
+          done
+          echo "Timed out waiting for the required status checks of $GITHUB_SHA to succeed."
+          exit 1
 
   helm-push:
     uses: ./.github/workflows/helm.yaml

--- a/.github/zizmor.yml
+++ b/.github/zizmor.yml
@@ -4,3 +4,5 @@ rules:
   artipacked:
     ignore:
       - docs.yaml
+      - release.yaml
+      - tag-on-release.yaml


### PR DESCRIPTION
## Context

Cutting v0.13.0 surfaced three problems in the release pipeline, and reviewing the flow around them turned up two more. This PR fixes all five.

## What changed

### The `workflow_call` condition never held

`helm.yaml` and `docs.yaml` gated their release steps on `github.event_name == 'workflow_call'`. A reusable workflow inherits the event of its **caller**, so that condition is unreachable — the event is `push`, not `workflow_call`. Consequences on v0.13.0: the chart was published as `0.13.0-<sha>` instead of `0.13.0`, and the documentation for the version was never deployed.

Both now branch on the `version` input, which is only populated by `workflow_call` / `workflow_dispatch`. The input is tested **before** the event, otherwise the inherited `push` would select the snapshot branch. The `workflow_dispatch` trigger added to `helm.yaml` as a hotfix in #969 is dropped, as it is no longer needed.

`docs.yaml` also gets a concurrency group: the release push runs it twice in parallel (standalone via its own `push` trigger, and through `tag-on-release.yaml`), and both `mike deploy --push` to `gh-pages`.

### The tag push raced its own required checks

The `releases` tag ruleset requires `Unit Tests`, `Check Codegen`, `build-and-push / merge` and `Build UI` to be green. Those checks are triggered by the same push as `tag-on-release.yaml`, so the first push attempt is always rejected with `GH013` and the workflow had to be re-run by hand.

The push now retries (45 x 60s) while the rejection is `GH013`, and aborts immediately on any other error so a genuine failure is not hidden behind a 45 minute wait.

### The tag could land on a commit that did not match the signed image

`main` can move between the build and the merge of the bump PR. The tag would then sit on a commit whose source no longer corresponds to the image that was built and signed — the signature attests to a build, but nothing tied it to the tagged source.

The release commit now carries a `Source-SHA` trailer, written both in the commit message and in the squash message so it survives either merge path. Before tagging, `tag-on-release.yaml` refuses to proceed when the trailer is missing, or when the diff against it touches anything outside `VERSION`, `Chart.yaml` and `values.yaml`.

Two related fixes: `release.yaml` now checks out `${{ github.sha }}` instead of `main` (these could already diverge *within a single run*, since the `version` job runs after `build-and-push`), and a `guard` job rejects a dispatch from any branch other than `main` — otherwise we publish and sign a `v0.x.y` image built from arbitrary code.

### `git push` could no longer authenticate (regression from #975)

Found while rebasing. #975 added `persist-credentials: false` to the checkouts of two jobs that then run `git push`: the tag push in `tag-on-release.yaml` and the bump branch push in `release.yaml`. Without persisted credentials those pushes have nothing to authenticate with and fail. The next release would have broken on both, so this PR fixes it rather than shipping on top of it.

Both jobs keep their credentials again, with matching `artipacked` exceptions in `.github/zizmor.yml`, exactly as `docs.yaml` already does. Every workflow that runs `git push` now handles this the same way.

### Fewer manual steps, same gates

The bump PR is now auto-merged. This removes waiting, not review: the `main` ruleset still applies in full. Cutting a release is also restricted to maintainers, as `workflow_dispatch` is otherwise open to anyone with write access — including `burrito-developers`.

The resulting flow is **dispatch -> approve the PR**, with everything else chained automatically, instead of dispatch -> wait for CI -> merge -> watch the tag -> re-run it.

## Reviewer notes

- **`Allow auto-merge` is currently disabled on this repository.** Until it is enabled, `gh pr merge --auto` emits a `::warning::` and the PR has to be merged by hand — the flow degrades gracefully rather than failing, and the `Source-SHA` trailer is carried by the commit message too, so a manual squash merge still works.
- The maintainer guard checks the **repository role** (`admin` or `maintain`), not membership of `burrito-maintainers`, because `GITHUB_TOKEN` has no org scope and reading team membership would require a PAT or a GitHub App. This matches the current setup (`burrito-maintainers` is `admin`, `burrito-developers` is `push`). Two caveats: granting `maintain` to someone outside the team would let them through, and the guard fails closed if the API call is ever denied — worth watching on the first release run.
- **Out of scope, but worth knowing:** `.github/CODEOWNERS` contains only handles with no path pattern. The first token of a CODEOWNERS line is the pattern, so each line declares a pattern with zero owners and no real path has a code owner — `require_code_owner_review: true` on the `main` ruleset is therefore inert today, and the effective gate is one approval from anyone with write access. Fixing it (`* @spoukke @Alan-pad ...`) would change access control on every PR in the repo, so it is left as a team decision.
- `docs/contributing/cicd.md` still describes the old flow (step 4 "a maintainer reviews and merges", no maintainer restriction, no integrity check). Happy to update it here or in a follow-up.

## Testing

No release has been run end to end yet — the next one is the real test. Verified locally:

- YAML of all 10 workflows parses.
- `zizmor` (the same audit CI runs, with the repo's `.github/zizmor.yml`): 3 low `self-repository` findings, 0 medium, 0 high — identical to what `main` reports today, so this PR introduces none.
- `Compute versions` branching over the 5 event paths — the previously broken `workflow_call` case now yields `0.14.0` instead of `0.13.0-<sha>`, snapshots unchanged.
- `Source-SHA` extraction against both squash message formats, plus a missing trailer and a malformed SHA.
- The release-files diff filter, including that another chart file is not whitelisted.
- The retry loop over its three outcomes: success after two `GH013` rejections, immediate abort on an unrelated error, clean timeout.
- Commit message against commitlint (`0 problems, 0 warnings`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
