### PR TITLE
fix(repository): synchronize CredentialStore reads with existing mutex

### DIFF
--- a/internal/repository/credentials/credentials.go
+++ b/internal/repository/credentials/credentials.go
@@ -40,13 +40,23 @@ func NewCredentialStore(client client.Client, ttl time.Duration) *CredentialStor
 }
 
 func (s *CredentialStore) GetAllCredentials() ([]*SharedCredential, []*RepositoryCredential) {
-	if time.Since(s.lastUpdate) >= s.TTL {
+	if s.isStale() {
 		err := s.updateCredentials()
 		if err != nil {
 			log.Errorf("Failed to update credentials: %v", err)
 		}
 	}
+	s.mu.Lock()
+	defer s.mu.Unlock()
 	return s.sharedCredentials, s.repositoryCredentials
+}
+
+// isStale reports whether the cached credentials are older than the TTL. It
+// takes the lock itself so callers must not hold s.mu when calling it.
+func (s *CredentialStore) isStale() bool {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return time.Since(s.lastUpdate) >= s.TTL
 }
 
 func (s *CredentialStore) updateCredentials() error {
@@ -99,19 +109,24 @@ func (s *CredentialStore) updateCredentials() error {
 // Returns the credentials for a given repository. If a specific repository credential is found, it will be returned.
 // If not, the most specific shared credential that matches the repository will be returned.
 func (s *CredentialStore) GetCredentials(repository *configv1alpha1.TerraformRepository) (*Credential, error) {
-	if time.Since(s.lastUpdate) >= s.TTL {
+	if s.isStale() {
 		err := s.updateCredentials()
 		if err != nil {
 			log.Errorf("failed to update credentials: %v", err)
 		}
 	}
-	for _, repositoryCredentials := range s.repositoryCredentials {
-		if repositoryCredentials.Matches(repository) {
-			return &repositoryCredentials.Credential, nil
+	s.mu.Lock()
+	repositoryCredentials := s.repositoryCredentials
+	sharedCredentials := s.sharedCredentials
+	s.mu.Unlock()
+
+	for _, repositoryCredential := range repositoryCredentials {
+		if repositoryCredential.Matches(repository) {
+			return &repositoryCredential.Credential, nil
 		}
 	}
 	var sharedCredential *SharedCredential
-	for _, tmp := range s.sharedCredentials {
+	for _, tmp := range sharedCredentials {
 		isAllowed := tmp.IsAllowed(repository)
 		matches := tmp.Matches(repository)
 		if isAllowed && matches {

--- a/internal/repository/credentials/credentials_test.go
+++ b/internal/repository/credentials/credentials_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"path/filepath"
+	"sync"
 	"testing"
 	"time"
 
@@ -128,6 +129,34 @@ var _ = Describe("Credentials", func() {
 				Expect(credentials.Username).To(Equal("username-match-1"))
 				Expect(credentials.Password).To(Equal("password-match-1"))
 			})
+		})
+	})
+	Describe("Concurrent access", Ordered, func() {
+		It("should not race when GetCredentials/GetAllCredentials run concurrently with a refresh", func() {
+			// TTL of 0 forces every call to attempt updateCredentials(), so reads
+			// (GetCredentials/GetAllCredentials) and writes (updateCredentials) are
+			// guaranteed to overlap across goroutines. Run with `go test -race`.
+			store := credentials.NewCredentialStore(k8sClient, 0)
+			repository := &configv1alpha1.TerraformRepository{}
+			err := k8sClient.Get(context.TODO(), types.NamespacedName{
+				Name:      "repository-secret-present",
+				Namespace: "default",
+			}, repository)
+			Expect(err).NotTo(HaveOccurred())
+
+			var wg sync.WaitGroup
+			for i := 0; i < 50; i++ {
+				wg.Add(2)
+				go func() {
+					defer wg.Done()
+					_, _ = store.GetCredentials(repository)
+				}()
+				go func() {
+					defer wg.Done()
+					store.GetAllCredentials()
+				}()
+			}
+			wg.Wait()
 		})
 	})
 })


### PR DESCRIPTION
## What

`CredentialStore.GetAllCredentials()` and `GetCredentials()` read `lastUpdate`, `sharedCredentials`, and `repositoryCredentials` without holding `s.mu`, while `updateCredentials()` writes those same fields under the lock. Confirmed with `go test -race`: a concurrent webhook request (`GetAllCredentials` via the webhook HTTP handler) and a concurrent reconcile (`GetCredentials`) racing against a refresh both trip the race detector on exactly the fields described in #963.

## Fix

- Added `isStale()`, a small helper that takes `s.mu` itself to check the TTL (must be called without already holding the lock, since it may be followed by `updateCredentials()`, which also locks).
- `GetAllCredentials()` and `GetCredentials()` now take `s.mu` to read the cached slices into local variables before iterating/returning, instead of reading the struct fields directly.
- `updateCredentials()` is untouched — it already locked correctly.

No behavior change: the TTL-based refresh semantics are the same, this only closes the unsynchronized-read window.

## Testing

- Added a `Concurrent access` spec to the existing Ginkgo suite in `internal/repository/credentials/credentials_test.go` that hits `GetCredentials`/`GetAllCredentials` from 100 goroutines against a store with `TTL: 0` (forces a refresh attempt on every call, guaranteeing overlap with `updateCredentials`).
- **Before the fix**, `go test ./internal/repository/credentials/... -race` fails with `WARNING: DATA RACE` at the exact lines called out in the issue (writes in `updateCredentials`, unsynchronized reads in `GetAllCredentials`/`GetCredentials`).
- **After the fix**, the same command passes clean (0 races, 6/6 specs green).
- `go vet ./internal/repository/...` and `golangci-lint run ./internal/repository/credentials/...` are clean on the changed package.

Note: on this local Windows dev machine, envtest's `AfterSuite` teardown fails with `unable to signal for process ... not supported by windows` — a pre-existing Windows-only envtest limitation unrelated to this change (process-signal teardown works fine on Linux, which is what CI runs). All 6 specs still report `Passed` before that unrelated teardown failure.

Closes #963