### PR TITLE
fix(ci): allow persisting git credentials in docs workflow

### DIFF
--- a/.github/workflows/docs.yaml
+++ b/.github/workflows/docs.yaml
@@ -27,7 +27,6 @@ jobs:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
         with:
           fetch-depth: 0  # Fetch all branches to include 'gh-pages' branch
-          persist-credentials: false
       - uses: astral-sh/setup-uv@11f9893b081a58869d3b5fccaea48c9e9e46f990
         with:
           enable-cache: true

--- a/.github/zizmor.yml
+++ b/.github/zizmor.yml
@@ -1,3 +1,6 @@
 rules:
   template-injection:
     disable: true
+  artipacked:
+    ignore:
+      - docs.yaml


### PR DESCRIPTION
Follow-up on https://github.com/padok-team/burrito/pull/975, cf. https://github.com/padok-team/burrito/actions/runs/31373796658/job/93409736936

Deploy docs on main is broken because git credentials are not persisted any more after checkout step, but those credentials are needed to be able to push to `gh-pages` branch later in the job.

Sorry for that!