### PR TITLE
fix(ci): grant `packages: write` permissions to `build-and-push` job

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -88,4 +88,5 @@ jobs:
   build-and-push:
     permissions:
       id-token: write # Required for keyless cosign signing (build-and-push.yaml)
+      packages: write
     uses: ./.github/workflows/build-and-push.yaml


### PR DESCRIPTION
Follow-up on https://github.com/padok-team/burrito/pull/975, `build-and-push` nested job requires `packages: write` permissions but it was not granted this permission when called in `Continuous Integration / build-and-push`, cf. https://github.com/padok-team/burrito/actions/runs/31474330563/workflow.