### PR TITLE
fix(controller): bound managed-by label values for long layer/run names

### DIFF
--- a/internal/controllers/terraformlayer/run.go
+++ b/internal/controllers/terraformlayer/run.go
@@ -7,11 +7,15 @@ import (
 
 	configv1alpha1 "github.com/padok-team/burrito/api/v1alpha1"
 	"github.com/padok-team/burrito/internal/annotations"
+	"github.com/padok-team/burrito/internal/utils"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/apimachinery/pkg/selection"
+	"k8s.io/apimachinery/pkg/util/validation"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )
+
+const managedByLabel = "burrito/managed-by"
 
 type Action string
 
@@ -22,8 +26,28 @@ const (
 
 func GetDefaultLabels(layer *configv1alpha1.TerraformLayer) map[string]string {
 	return map[string]string{
-		"burrito/managed-by": layer.Name,
+		managedByLabel: managedByLabelValue(layer),
 	}
+}
+
+func managedByLabelValue(layer *configv1alpha1.TerraformLayer) string {
+	// Kubernetes label values max out at 63 bytes; a stable hash keeps long
+	// layer names valid while still linking created runs back to the layer.
+	return fmt.Sprintf("layer-%s", utils.ShortHash(fmt.Sprintf("%s/%s", layer.Namespace, layer.Name)))
+}
+
+// managedByLabelSelectorValues returns every "burrito/managed-by" value a run
+// belonging to this layer may carry: the current hash-based value, plus the
+// legacy raw layer name for runs created before that hashing was introduced.
+// The legacy value is only included when it's a valid label value, since a
+// layer name that isn't (the case this hashing fixes) could never have been
+// used as a label before either.
+func managedByLabelSelectorValues(layer *configv1alpha1.TerraformLayer) []string {
+	values := []string{managedByLabelValue(layer)}
+	if len(validation.IsValidLabelValue(layer.Name)) == 0 {
+		values = append(values, layer.Name)
+	}
+	return values
 }
 
 func (r *Reconciler) getRun(layer *configv1alpha1.TerraformLayer, revision string, action Action) configv1alpha1.TerraformRun {
@@ -61,15 +85,12 @@ func (r *Reconciler) getRun(layer *configv1alpha1.TerraformLayer, revision strin
 
 func (r *Reconciler) getAllRuns(ctx context.Context, layer *configv1alpha1.TerraformLayer) ([]*configv1alpha1.TerraformRun, error) {
 	list := &configv1alpha1.TerraformRunList{}
-	labelSelector := labels.NewSelector()
-	for key, value := range GetDefaultLabels(layer) {
-		requirement, err := labels.NewRequirement(key, selection.Equals, []string{value})
-		if err != nil {
-			return []*configv1alpha1.TerraformRun{}, err
-		}
-		labelSelector = labelSelector.Add(*requirement)
+	requirement, err := labels.NewRequirement(managedByLabel, selection.In, managedByLabelSelectorValues(layer))
+	if err != nil {
+		return []*configv1alpha1.TerraformRun{}, err
 	}
-	err := r.Client.List(
+	labelSelector := labels.NewSelector().Add(*requirement)
+	err = r.Client.List(
 		ctx,
 		list,
 		client.MatchingLabelsSelector{Selector: labelSelector},

--- a/internal/controllers/terraformlayer/run_test.go
+++ b/internal/controllers/terraformlayer/run_test.go
@@ -1,0 +1,139 @@
+package terraformlayer
+
+import (
+	"context"
+	"strings"
+	"testing"
+
+	configv1alpha1 "github.com/padok-team/burrito/api/v1alpha1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+)
+
+func newRunTestScheme(t *testing.T) *runtime.Scheme {
+	t.Helper()
+	scheme := runtime.NewScheme()
+	if err := configv1alpha1.AddToScheme(scheme); err != nil {
+		t.Fatalf("failed to add burrito scheme: %v", err)
+	}
+	return scheme
+}
+
+func TestGetDefaultLabelsBoundsManagedByValue(t *testing.T) {
+	layer := &configv1alpha1.TerraformLayer{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      strings.Repeat("a", 250),
+			Namespace: "default",
+		},
+	}
+
+	labels := GetDefaultLabels(layer)
+
+	value := labels["burrito/managed-by"]
+	if got := len(value); got > 63 {
+		t.Fatalf("expected managed-by label length <= 63, got %d", got)
+	}
+	if value == layer.Name {
+		t.Fatal("expected managed-by label to use a bounded hash instead of the raw layer name")
+	}
+}
+
+func TestGetDefaultLabelsIsDeterministic(t *testing.T) {
+	layer := &configv1alpha1.TerraformLayer{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      strings.Repeat("a", 250),
+			Namespace: "default",
+		},
+	}
+
+	if GetDefaultLabels(layer)["burrito/managed-by"] != GetDefaultLabels(layer)["burrito/managed-by"] {
+		t.Fatal("expected managed-by label to be deterministic for the same layer")
+	}
+}
+
+func TestManagedByLabelSelectorValuesIncludesLegacyRawName(t *testing.T) {
+	layer := &configv1alpha1.TerraformLayer{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "short-layer-name",
+			Namespace: "default",
+		},
+	}
+
+	values := managedByLabelSelectorValues(layer)
+
+	if len(values) != 2 {
+		t.Fatalf("expected 2 selector values, got %d: %v", len(values), values)
+	}
+	if values[0] != managedByLabelValue(layer) {
+		t.Fatalf("expected first value to be the hash-based value, got %q", values[0])
+	}
+	if !contains(values, layer.Name) {
+		t.Fatalf("expected selector values to include the legacy raw layer name, got %v", values)
+	}
+}
+
+func TestManagedByLabelSelectorValuesExcludesInvalidLegacyName(t *testing.T) {
+	layer := &configv1alpha1.TerraformLayer{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      strings.Repeat("a", 250),
+			Namespace: "default",
+		},
+	}
+
+	values := managedByLabelSelectorValues(layer)
+
+	if len(values) != 1 {
+		t.Fatalf("expected only the hash-based value for a name that's never been a valid label, got %v", values)
+	}
+}
+
+func TestGetAllRunsFindsLegacyLabeledRuns(t *testing.T) {
+	layer := &configv1alpha1.TerraformLayer{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "short-layer-name",
+			Namespace: "default",
+		},
+	}
+	legacyRun := &configv1alpha1.TerraformRun{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "legacy-run",
+			Namespace: "default",
+			Labels:    map[string]string{managedByLabel: layer.Name},
+		},
+	}
+	currentRun := &configv1alpha1.TerraformRun{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "current-run",
+			Namespace: "default",
+			Labels:    GetDefaultLabels(layer),
+		},
+	}
+	otherLayerRun := &configv1alpha1.TerraformRun{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "other-run",
+			Namespace: "default",
+			Labels:    map[string]string{managedByLabel: "some-other-layer"},
+		},
+	}
+	scheme := newRunTestScheme(t)
+	cl := fake.NewClientBuilder().WithScheme(scheme).WithObjects(legacyRun, currentRun, otherLayerRun).Build()
+	reconciler := &Reconciler{Client: cl}
+
+	runs, err := reconciler.getAllRuns(context.Background(), layer)
+	if err != nil {
+		t.Fatalf("getAllRuns returned error: %v", err)
+	}
+	if len(runs) != 2 {
+		t.Fatalf("expected to find both the legacy and current run, got %d", len(runs))
+	}
+}
+
+func contains(values []string, target string) bool {
+	for _, v := range values {
+		if v == target {
+			return true
+		}
+	}
+	return false
+}

--- a/internal/controllers/terraformpullrequest/layer.go
+++ b/internal/controllers/terraformpullrequest/layer.go
@@ -2,8 +2,6 @@ package terraformpullrequest
 
 import (
 	"context"
-	"crypto/sha256"
-	"encoding/hex"
 	"fmt"
 	"slices"
 
@@ -16,6 +14,7 @@ import (
 	configv1alpha1 "github.com/padok-team/burrito/api/v1alpha1"
 	"github.com/padok-team/burrito/internal/annotations"
 	controller "github.com/padok-team/burrito/internal/controllers/terraformlayer"
+	"github.com/padok-team/burrito/internal/utils"
 	logrus "github.com/sirupsen/logrus"
 )
 
@@ -171,7 +170,7 @@ func (r *Reconciler) deleteTempLayersByLabel(ctx context.Context, pr *configv1al
 }
 
 func tempLayerGenerateName(layerName string, pr *configv1alpha1.TerraformPullRequest) string {
-	hash := shortHash(fmt.Sprintf("%s/%s/%s", pr.Namespace, pr.Name, pr.Spec.ID))
+	hash := utils.ShortHash(fmt.Sprintf("%s/%s/%s", pr.Namespace, pr.Name, pr.Spec.ID))
 	prefix := fmt.Sprintf("%s-pr-%s-", layerName, hash)
 	if len(prefix) <= maxGenerateNamePrefixLength {
 		return prefix
@@ -182,10 +181,5 @@ func tempLayerGenerateName(layerName string, pr *configv1alpha1.TerraformPullReq
 func managedByLabelValue(pr *configv1alpha1.TerraformPullRequest) string {
 	// Kubernetes label values max out at 63 chars; a stable hash keeps long PR
 	// names valid while still linking generated layers back to the same PR.
-	return fmt.Sprintf("pr-%s", shortHash(fmt.Sprintf("%s/%s", pr.Namespace, pr.Name)))
-}
-
-func shortHash(value string) string {
-	sum := sha256.Sum256([]byte(value))
-	return hex.EncodeToString(sum[:])[:16]
+	return fmt.Sprintf("pr-%s", utils.ShortHash(fmt.Sprintf("%s/%s", pr.Namespace, pr.Name)))
 }

--- a/internal/controllers/terraformrun/labels_test.go
+++ b/internal/controllers/terraformrun/labels_test.go
@@ -1,0 +1,156 @@
+package terraformrun
+
+import (
+	"strings"
+	"testing"
+
+	configv1alpha1 "github.com/padok-team/burrito/api/v1alpha1"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+)
+
+func newLabelsTestScheme(t *testing.T) *runtime.Scheme {
+	t.Helper()
+	scheme := runtime.NewScheme()
+	if err := corev1.AddToScheme(scheme); err != nil {
+		t.Fatalf("failed to add core scheme: %v", err)
+	}
+	if err := configv1alpha1.AddToScheme(scheme); err != nil {
+		t.Fatalf("failed to add burrito scheme: %v", err)
+	}
+	return scheme
+}
+
+func TestGetDefaultLabelsBoundsManagedByValue(t *testing.T) {
+	run := &configv1alpha1.TerraformRun{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      strings.Repeat("a", 250),
+			Namespace: "default",
+		},
+		Spec: configv1alpha1.TerraformRunSpec{
+			Action: "plan",
+		},
+	}
+
+	labels := getDefaultLabels(run)
+
+	value := labels["burrito/managed-by"]
+	if got := len(value); got > 63 {
+		t.Fatalf("expected managed-by label length <= 63, got %d", got)
+	}
+	if value == run.Name {
+		t.Fatal("expected managed-by label to use a bounded hash instead of the raw run name")
+	}
+}
+
+func TestGetDefaultLabelsIsDeterministic(t *testing.T) {
+	run := &configv1alpha1.TerraformRun{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      strings.Repeat("a", 250),
+			Namespace: "default",
+		},
+		Spec: configv1alpha1.TerraformRunSpec{
+			Action: "plan",
+		},
+	}
+
+	if getDefaultLabels(run)["burrito/managed-by"] != getDefaultLabels(run)["burrito/managed-by"] {
+		t.Fatal("expected managed-by label to be deterministic for the same run")
+	}
+}
+
+func TestManagedByLabelSelectorValuesIncludesLegacyRawName(t *testing.T) {
+	run := &configv1alpha1.TerraformRun{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "short-run-name",
+			Namespace: "default",
+		},
+	}
+
+	values := managedByLabelSelectorValues(run)
+
+	if len(values) != 2 {
+		t.Fatalf("expected 2 selector values, got %d: %v", len(values), values)
+	}
+	if !contains(values, run.Name) {
+		t.Fatalf("expected selector values to include the legacy raw run name, got %v", values)
+	}
+}
+
+func TestManagedByLabelSelectorValuesExcludesInvalidLegacyName(t *testing.T) {
+	run := &configv1alpha1.TerraformRun{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      strings.Repeat("a", 250),
+			Namespace: "default",
+		},
+	}
+
+	values := managedByLabelSelectorValues(run)
+
+	if len(values) != 1 {
+		t.Fatalf("expected only the hash-based value for a name that's never been a valid label, got %v", values)
+	}
+}
+
+func TestGetLinkedPodsFindsLegacyLabeledPods(t *testing.T) {
+	run := &configv1alpha1.TerraformRun{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "short-run-name",
+			Namespace: "default",
+		},
+		Spec: configv1alpha1.TerraformRunSpec{
+			Action: "plan",
+		},
+	}
+	legacyPod := &corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "legacy-pod",
+			Namespace: "default",
+			Labels: map[string]string{
+				"burrito/component": "runner",
+				"burrito/action":    "plan",
+				managedByLabel:      run.Name,
+			},
+		},
+	}
+	currentPod := &corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "current-pod",
+			Namespace: "default",
+			Labels:    getDefaultLabels(run),
+		},
+	}
+	otherRunPod := &corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "other-pod",
+			Namespace: "default",
+			Labels: map[string]string{
+				"burrito/component": "runner",
+				"burrito/action":    "plan",
+				managedByLabel:      "some-other-run",
+			},
+		},
+	}
+	scheme := newLabelsTestScheme(t)
+	cl := fake.NewClientBuilder().WithScheme(scheme).WithObjects(legacyPod, currentPod, otherRunPod).Build()
+	reconciler := &Reconciler{Client: cl}
+
+	pods, err := reconciler.GetLinkedPods(run)
+	if err != nil {
+		t.Fatalf("GetLinkedPods returned error: %v", err)
+	}
+	if len(pods.Items) != 2 {
+		t.Fatalf("expected to find both the legacy and current pod, got %d", len(pods.Items))
+	}
+}
+
+func contains(values []string, target string) bool {
+	for _, v := range values {
+		if v == target {
+			return true
+		}
+	}
+	return false
+}

--- a/internal/controllers/terraformrun/pod.go
+++ b/internal/controllers/terraformrun/pod.go
@@ -7,11 +7,13 @@ import (
 
 	configv1alpha1 "github.com/padok-team/burrito/api/v1alpha1"
 	"github.com/padok-team/burrito/internal/burrito/config"
+	"github.com/padok-team/burrito/internal/utils"
 	corev1 "k8s.io/api/core/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/apimachinery/pkg/selection"
+	"k8s.io/apimachinery/pkg/util/validation"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
@@ -22,24 +24,53 @@ const (
 	ApplyAction Action = "apply"
 )
 
+const managedByLabel = "burrito/managed-by"
+
 func getDefaultLabels(run *configv1alpha1.TerraformRun) map[string]string {
 	return map[string]string{
-		"burrito/component":  "runner",
-		"burrito/managed-by": run.Name,
-		"burrito/action":     string(run.Spec.Action),
+		"burrito/component": "runner",
+		managedByLabel:      managedByLabelValue(run),
+		"burrito/action":    string(run.Spec.Action),
 	}
+}
+
+func managedByLabelValue(run *configv1alpha1.TerraformRun) string {
+	// Kubernetes label values max out at 63 bytes; a stable hash keeps long
+	// run names valid while still linking created pods back to the run.
+	return fmt.Sprintf("run-%s", utils.ShortHash(fmt.Sprintf("%s/%s", run.Namespace, run.Name)))
+}
+
+// managedByLabelSelectorValues returns every "burrito/managed-by" value a pod
+// belonging to this run may carry: the current hash-based value, plus the
+// legacy raw run name for pods created before that hashing was introduced.
+// The legacy value is only included when it's a valid label value, since a
+// run name that isn't (the case this hashing fixes) could never have been
+// used as a label before either.
+func managedByLabelSelectorValues(run *configv1alpha1.TerraformRun) []string {
+	values := []string{managedByLabelValue(run)}
+	if len(validation.IsValidLabelValue(run.Name)) == 0 {
+		values = append(values, run.Name)
+	}
+	return values
 }
 
 func getLabelSelector(run *configv1alpha1.TerraformRun) labels.Selector {
 	selector := labels.NewSelector()
-	for key, value := range getDefaultLabels(run) {
+	for key, value := range map[string]string{
+		"burrito/component": "runner",
+		"burrito/action":    string(run.Spec.Action),
+	} {
 		requirement, err := labels.NewRequirement(key, selection.Equals, []string{value})
 		if err != nil {
 			return selector
 		}
 		selector = selector.Add(*requirement)
 	}
-	return selector
+	managedByRequirement, err := labels.NewRequirement(managedByLabel, selection.In, managedByLabelSelectorValues(run))
+	if err != nil {
+		return selector
+	}
+	return selector.Add(*managedByRequirement)
 }
 
 func (r *Reconciler) GetLinkedPods(run *configv1alpha1.TerraformRun) (*corev1.PodList, error) {

--- a/internal/utils/hash.go
+++ b/internal/utils/hash.go
@@ -1,0 +1,14 @@
+package utils
+
+import (
+	"crypto/sha256"
+	"encoding/hex"
+)
+
+// ShortHash returns a short, deterministic, label-safe hash of value: 16
+// lowercase hex characters, well within Kubernetes' 63-byte label value limit
+// even after adding a short prefix.
+func ShortHash(value string) string {
+	sum := sha256.Sum256([]byte(value))
+	return hex.EncodeToString(sum[:])[:16]
+}

--- a/internal/utils/hash_test.go
+++ b/internal/utils/hash_test.go
@@ -1,0 +1,15 @@
+package utils
+
+import "testing"
+
+func TestShortHashIsDeterministicAndBounded(t *testing.T) {
+	if ShortHash("a") != ShortHash("a") {
+		t.Fatal("expected ShortHash to be deterministic for the same input")
+	}
+	if ShortHash("a") == ShortHash("b") {
+		t.Fatal("expected ShortHash to differ for different inputs")
+	}
+	if got := len(ShortHash("a")); got != 16 {
+		t.Fatalf("expected ShortHash length 16, got %d", got)
+	}
+}


### PR DESCRIPTION
## Summary
- Kubernetes label values are capped at 63 bytes. `TerraformLayer` and `TerraformRun` reconcilers used raw layer/run names as the `burrito/managed-by` label value, so any layer with a name longer than 63 characters failed to create its `TerraformRun` (and would have failed Pod creation right after, since `TerraformRun` object names are even longer).
- Replaced the raw name with a stable short hash, mirroring the pattern already used for `TerraformPullRequest` temp layers (extracted the shared hashing helper into `internal/utils` to avoid a third copy).
- Selectors used for cleanup (`cleanupRuns`) and pod lookup (`GetLinkedPods`) also match the legacy raw-name label value, so runs/pods created by a previous version of the operator are still found after upgrade.

Fixes #986

## Test plan
- [x] `go build ./...`
- [x] `go vet ./...`
- [x] New unit tests: bounded/deterministic label values, legacy-label backward compatibility for `getAllRuns` and `GetLinkedPods`
- [x] Existing unit tests in `terraformlayer`, `terraformrun`, `terraformpullrequest` pass with no regressions
- [ ] Full `make test` (envtest/docker-compose suite) not run locally — CI will cover it

🤖 Generated with [Claude Code](https://claude.com/claude-code)