### PR TITLE
fix(renovate): enable auto-lowercase for docker commits

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -43,7 +43,7 @@
       "separateMajorMinor": false,
       "separateMinorPatch": false,
       "pinDigests": true,
-      "commitMessagePrefix": "chore(docker):",
+      "semanticCommitScope": "docker",
       "groupName": "Docker images",
       "groupSlug": "docker-all",
       "addLabels": [


### PR DESCRIPTION
## Summary
Replace manual `commitMessagePrefix` with `semanticCommitScope` in the dockerfile package rule to ensure Renovate's semantic commit lowercasing is applied.

## Problem
Renovate only auto-lowercases commit messages when semantic commits are enabled **and** no manual `commitMessagePrefix` is set. The dockerfile rule was using a hardcoded prefix, bypassing this step, causing commits like:
```
chore(docker): Update docker.io/library/golang:1.26.6-alpine Docker digest to 3889b42
```
which failed commitlint's `subject-case` rule (capital U violates the rule).

## Solution  
Use `semanticCommitScope: "docker"` instead, which lets Renovate rebuild the prefix through its normal semantic commit path, keeping the auto-lowercase step active.

## Test plan
- Docker-related Renovate commits will now start with lowercase: `chore(docker): update ...`
- Should pass commitlint checks
- All existing docker grouping/labeling behavior preserved

🤖 Generated with [Claude Code](https://claude.com/claude-code)