### PR TITLE
fix(controller): scope layer lock key to branch

### DIFF
--- a/internal/controllers/terraformlayer/testdata/nominal-case.yaml
+++ b/internal/controllers/terraformlayer/testdata/nominal-case.yaml
@@ -158,7 +158,7 @@ spec:
 apiVersion: coordination.k8s.io/v1
 kind: Lease
 metadata:
-  name: burrito-layer-lock-953655719
+  name: burrito-layer-lock-1842901862
   namespace: default
 spec:
   holderIdentity: burrito-controller

--- a/internal/lock/lock.go
+++ b/internal/lock/lock.go
@@ -22,7 +22,7 @@ func hash(s string) uint32 {
 }
 
 func getLeaseName(layer *configv1alpha1.TerraformLayer) string {
-	return fmt.Sprintf("%s-%d", lockPrefix, hash(layer.Spec.Repository.Name+layer.Spec.Repository.Namespace+layer.Spec.Path))
+	return fmt.Sprintf("%s-%d", lockPrefix, hash(layer.Spec.Repository.Name+layer.Spec.Repository.Namespace+layer.Spec.Path+layer.Spec.Branch))
 }
 
 func getLeaseLock(layer *configv1alpha1.TerraformLayer, run *configv1alpha1.TerraformRun) *coordination.Lease {

--- a/internal/lock/lock_test.go
+++ b/internal/lock/lock_test.go
@@ -100,6 +100,45 @@ var _ = Describe("Lock", func() {
 			Expect(locked).To(Equal(false))
 		})
 	})
+
+	Describe("Lock key scoping", func() {
+		var mainLayer *configv1alpha1.TerraformLayer
+		var otherBranchLayer *configv1alpha1.TerraformLayer
+		var mainRun *configv1alpha1.TerraformRun
+		BeforeEach(func() {
+			mainLayer = &configv1alpha1.TerraformLayer{}
+			err := k8sClient.Get(context.TODO(), types.NamespacedName{
+				Namespace: "default",
+				Name:      "test",
+			}, mainLayer)
+			Expect(err).NotTo(HaveOccurred())
+
+			otherBranchLayer = &configv1alpha1.TerraformLayer{}
+			err = k8sClient.Get(context.TODO(), types.NamespacedName{
+				Namespace: "default",
+				Name:      "test-other-branch",
+			}, otherBranchLayer)
+			Expect(err).NotTo(HaveOccurred())
+
+			mainRun = &configv1alpha1.TerraformRun{}
+			err = k8sClient.Get(context.TODO(), types.NamespacedName{
+				Namespace: "default",
+				Name:      "test-run",
+			}, mainRun)
+			Expect(err).NotTo(HaveOccurred())
+		})
+		It("should not lock a layer on the same repository/path but a different branch", func() {
+			err := lock.CreateLock(context.TODO(), k8sClient, mainLayer, mainRun)
+			Expect(err).NotTo(HaveOccurred())
+
+			locked, err := lock.IsLayerLocked(context.TODO(), k8sClient, otherBranchLayer)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(locked).To(Equal(false))
+
+			err = lock.DeleteLock(context.TODO(), k8sClient, mainLayer, mainRun)
+			Expect(err).NotTo(HaveOccurred())
+		})
+	})
 })
 
 var _ = AfterSuite(func() {

--- a/internal/lock/testdata/layer.yaml
+++ b/internal/lock/testdata/layer.yaml
@@ -27,3 +27,22 @@ spec:
   layer:
     name: test
     namespace: default
+---
+apiVersion: config.terraform.padok.cloud/v1alpha1
+kind: TerraformLayer
+metadata:
+  name: test-other-branch
+  namespace: default
+spec:
+  branch: pr-6
+  path: test/
+  remediationStrategy:
+    autoApply: true
+  repository:
+    name: burrito
+    namespace: default
+  terraform:
+    version: 1.3.1
+  terragrunt:
+    enabled: true
+    version: 0.45.4


### PR DESCRIPTION
## Summary

- The layer `Lease` lock key was derived from `repository + path` only (`internal/lock/lock.go`), ignoring `branch`.
- Temporary layers generated for a `TerraformPullRequest` clone the base layer's `repository`/`path` and only change `branch` (`internal/controllers/terraformpullrequest/layer.go`), so they end up computing the **same lock key** as the base layer.
- If the base layer's run is failing and retrying (e.g. a path that doesn't exist yet on `main`), it holds the lock for its entire retry cycle, blocking reconciliation of the PR-generated layer for that whole time — even though they target different branches.

This fixes the root cause reported in #906, where a layer created via the API and its PR counterpart (same repo/path, different branch) got stuck behind each other's lock for ~10 minutes.

## Changes

- `internal/lock/lock.go`: include `layer.Spec.Branch` in the lock key hash.
- `internal/lock/lock_test.go` + `internal/lock/testdata/layer.yaml`: add a regression test asserting two layers on the same repository/path but different branches don't share a lock.
- `internal/controllers/terraformlayer/testdata/nominal-case.yaml`: update the hardcoded `Lease` name fixture used by the existing "shares a path" test (same branch, same path) to match the new hash formula — this scenario is unchanged and still locks as before.

Fixes #906

## Test plan

- [x] `go test ./internal/lock/...` — all specs pass, including new branch-scoping case
- [x] `go test ./internal/controllers/...` — all suites pass (existing same-branch/same-path lock test still asserts locking, with updated fixture)
- [x] `go build ./...`, `gofmt -l` clean on changed files
- [ ] `golangci-lint run ./...` (not runnable locally in this environment — will run in CI)

🤖 Generated with [Claude Code](https://claude.com/claude-code)