### PR TITLE
feat: add non-destructive apply support

### DIFF
--- a/api/v1alpha1/common.go
+++ b/api/v1alpha1/common.go
@@ -45,6 +45,7 @@ type RunHistoryPolicy struct {
 type RemediationStrategy struct {
 	AutoApply                *bool                      `json:"autoApply,omitempty"`
 	ApplyWithoutPlanArtifact *bool                      `json:"applyWithoutPlanArtifact,omitempty"`
+	NonDestructiveApply      *bool                      `json:"nonDestructiveApply,omitempty"`
 	OnError                  OnErrorRemediationStrategy `json:"onError,omitempty"`
 }
 
@@ -132,6 +133,10 @@ func GetRunHistoryPolicy(repository *TerraformRepository, layer *TerraformLayer)
 
 func GetApplyWithoutPlanArtifactEnabled(repository *TerraformRepository, layer *TerraformLayer) bool {
 	return chooseBool(repository.Spec.RemediationStrategy.ApplyWithoutPlanArtifact, layer.Spec.RemediationStrategy.ApplyWithoutPlanArtifact, false)
+}
+
+func GetNonDestructiveApplyEnabled(repository *TerraformRepository, layer *TerraformLayer) bool {
+	return chooseBool(repository.Spec.RemediationStrategy.NonDestructiveApply, layer.Spec.RemediationStrategy.NonDestructiveApply, false)
 }
 
 func GetAutoApplyEnabled(repo *TerraformRepository, layer *TerraformLayer) bool {

--- a/api/v1alpha1/common_test.go
+++ b/api/v1alpha1/common_test.go
@@ -516,6 +516,126 @@ func TestGetApplyWithoutPlanArtifactEnabled(t *testing.T) {
 	}
 }
 
+func TestGetNonDestructiveApplyEnabled(t *testing.T) {
+	tt := []struct {
+		name       string
+		repository *configv1alpha1.TerraformRepository
+		layer      *configv1alpha1.TerraformLayer
+		expected   bool
+	}{
+		{
+			"EnabledInRepositoryDisabledInLayer",
+			&configv1alpha1.TerraformRepository{
+				Spec: configv1alpha1.TerraformRepositorySpec{
+					RemediationStrategy: configv1alpha1.RemediationStrategy{
+						NonDestructiveApply: &[]bool{true}[0],
+					},
+				},
+			},
+			&configv1alpha1.TerraformLayer{
+				Spec: configv1alpha1.TerraformLayerSpec{
+					RemediationStrategy: configv1alpha1.RemediationStrategy{
+						NonDestructiveApply: &[]bool{false}[0],
+					},
+				},
+			},
+			false,
+		},
+		{
+			"DisabledInRepositoryEnabledInLayer",
+			&configv1alpha1.TerraformRepository{
+				Spec: configv1alpha1.TerraformRepositorySpec{
+					RemediationStrategy: configv1alpha1.RemediationStrategy{
+						NonDestructiveApply: &[]bool{false}[0],
+					},
+				},
+			},
+			&configv1alpha1.TerraformLayer{
+				Spec: configv1alpha1.TerraformLayerSpec{
+					RemediationStrategy: configv1alpha1.RemediationStrategy{
+						NonDestructiveApply: &[]bool{true}[0],
+					},
+				},
+			},
+			true,
+		},
+		{
+			"EnabledInRepositoryEnabledInLayer",
+			&configv1alpha1.TerraformRepository{
+				Spec: configv1alpha1.TerraformRepositorySpec{
+					RemediationStrategy: configv1alpha1.RemediationStrategy{
+						NonDestructiveApply: &[]bool{true}[0],
+					},
+				},
+			},
+			&configv1alpha1.TerraformLayer{
+				Spec: configv1alpha1.TerraformLayerSpec{
+					RemediationStrategy: configv1alpha1.RemediationStrategy{
+						NonDestructiveApply: &[]bool{true}[0],
+					},
+				},
+			},
+			true,
+		},
+		{
+			"DisabledInRepositoryDisabledInLayer",
+			&configv1alpha1.TerraformRepository{
+				Spec: configv1alpha1.TerraformRepositorySpec{
+					RemediationStrategy: configv1alpha1.RemediationStrategy{
+						NonDestructiveApply: &[]bool{false}[0],
+					},
+				},
+			},
+			&configv1alpha1.TerraformLayer{
+				Spec: configv1alpha1.TerraformLayerSpec{
+					RemediationStrategy: configv1alpha1.RemediationStrategy{
+						NonDestructiveApply: &[]bool{false}[0],
+					},
+				},
+			},
+			false,
+		},
+		{
+			"OnlyRepositoryEnabling",
+			&configv1alpha1.TerraformRepository{
+				Spec: configv1alpha1.TerraformRepositorySpec{
+					RemediationStrategy: configv1alpha1.RemediationStrategy{
+						NonDestructiveApply: &[]bool{true}[0],
+					},
+				},
+			},
+			&configv1alpha1.TerraformLayer{},
+			true,
+		},
+		{
+			"OnlyLayerEnabling",
+			&configv1alpha1.TerraformRepository{},
+			&configv1alpha1.TerraformLayer{
+				Spec: configv1alpha1.TerraformLayerSpec{
+					RemediationStrategy: configv1alpha1.RemediationStrategy{
+						NonDestructiveApply: &[]bool{true}[0],
+					},
+				},
+			},
+			true,
+		},
+		{
+			"DisabledByDefault",
+			&configv1alpha1.TerraformRepository{},
+			&configv1alpha1.TerraformLayer{},
+			false,
+		},
+	}
+
+	for _, tc := range tt {
+		t.Run(tc.name, func(t *testing.T) {
+			result := configv1alpha1.GetNonDestructiveApplyEnabled(tc.repository, tc.layer)
+			if tc.expected != result {
+				t.Errorf("different enabled status computed: expected %t got %t", tc.expected, result)
+			}
+		})
+	}
+}
 func TestGetAutoApplyEnabled(t *testing.T) {
 	tt := []struct {
 		name       string

--- a/internal/runner/actions.go
+++ b/internal/runner/actions.go
@@ -107,7 +107,7 @@ func (r *Runner) execPlan() (string, error) {
 		log.Errorf("error parsing %s json plan: %s", r.exec.TenvName(), err)
 		return "", err
 	}
-	_, shortDiff := runnerutils.GetDiff(plan)
+	_, _, shortDiff := runnerutils.GetDiff(plan)
 	err = r.Datastore.PutPlan(r.Layer.Namespace, r.Layer.Name, r.Run.Name, strconv.Itoa(r.Run.Status.Retries), "json", planJsonBytes)
 	if err != nil {
 		log.Errorf("could not put json plan in datastore: %s", err)
@@ -144,6 +144,43 @@ func (r *Runner) execApply() (string, error) {
 	if err != nil {
 		log.Errorf("could not get plan artifact: %s", err)
 		return "", err
+	}
+	if configv1alpha1.GetNonDestructiveApplyEnabled(r.Repository, r.Layer) {
+		planJSON, err := r.Datastore.GetPlan(
+			r.Layer.Namespace,
+			r.Layer.Name,
+			r.Run.Spec.Artifact.Run,
+			r.Run.Spec.Artifact.Attempt,
+			"json",
+		)
+		if err != nil {
+			log.Errorf("could not get plan JSON for destructive change check: %s", err)
+			return "", err
+		}
+
+		plan := &tfjson.Plan{}
+		err = json.Unmarshal(planJSON, plan)
+		if err != nil {
+			log.Errorf("could not parse plan JSON for destructive change check: %s", err)
+			return "", err
+		}
+
+		_, destructive, _ := runnerutils.GetDiff(plan)
+		if destructive {
+			log.Infof("nonDestructiveApply is enabled and plan contains destructive changes, skipping apply")
+			err = r.Datastore.PutPlan(
+				r.Layer.Namespace,
+				r.Layer.Name,
+				r.Run.Name,
+				strconv.Itoa(r.Run.Status.Retries),
+				"short",
+				[]byte("Apply skipped: plan contains destructive changes"),
+			)
+			if err != nil {
+				log.Errorf("could not put short plan in datastore: %s", err)
+			}
+			return "", fmt.Errorf("apply blocked: plan contains destructive changes")
+		}
 	}
 	sum := sha256.Sum256(plan)
 	err = os.WriteFile(PlanArtifact, plan, 0644)

--- a/internal/utils/runner/plan_diff.go
+++ b/internal/utils/runner/plan_diff.go
@@ -6,11 +6,16 @@ import (
 	tfjson "github.com/hashicorp/terraform-json"
 )
 
-// Produces a diff summary from the given plan
-func GetDiff(plan *tfjson.Plan) (bool, string) {
+// Produces a diff summary from the given plan.
+// Returns:
+//   - whether the plan has any changes
+//   - whether the plan contains destructive changes
+//   - a human-readable summary
+func GetDiff(plan *tfjson.Plan) (bool, bool, string) {
 	delete := 0
 	create := 0
 	update := 0
+
 	for _, res := range plan.ResourceChanges {
 		if res.Change.Actions.Create() {
 			create++
@@ -26,9 +31,14 @@ func GetDiff(plan *tfjson.Plan) (bool, string) {
 			delete++
 		}
 	}
-	diff := false
-	if create+delete+update > 0 {
-		diff = true
-	}
-	return diff, fmt.Sprintf("Plan: %d to create, %d to update, %d to delete", create, update, delete)
+
+	diff := create+delete+update > 0
+	destructive := delete > 0
+
+	return diff, destructive, fmt.Sprintf(
+		"Plan: %d to create, %d to update, %d to delete",
+		create,
+		update,
+		delete,
+	)
 }

--- a/internal/utils/runner/plan_diff.go
+++ b/internal/utils/runner/plan_diff.go
@@ -42,3 +42,5 @@ func GetDiff(plan *tfjson.Plan) (bool, bool, string) {
 		delete,
 	)
 }
+
+// Diff summary helpers


### PR DESCRIPTION
## Summary

- Add `nonDestructiveApply` remediation strategy
- Prevent apply when Terraform plan contains destructive changes
- Preserve repository-level configuration with layer-level override behavior
- Add configuration tests

## Testing

- `go test ./api/v1alpha1`
- `go test ./internal/runner`
- Runner suite reached 14 passing specs; one end-to-end case was blocked by GitHub API rate limiting during Terragrunt binary download.