### PR TITLE
chore(deps): require 3-day minimum release age before renovate upgrades

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -11,6 +11,7 @@
   ],
   "commitMessageLowerCase": "auto",
   "prHourlyLimit": 10,
+  "minimumReleaseAge": "3 days",
   "packageRules": [
     {
       "matchManagers": [


### PR DESCRIPTION
## Summary
- Add `minimumReleaseAge: "3 days"` to `renovate.json` so Renovate waits at least 3 days after a release is published before proposing it as an update.

## Test plan
- [ ] Confirm Renovate config validates (renovate config-validator, or check the Renovate dashboard/logs after merge)
- [ ] Confirm subsequent dependency PRs are only opened for releases at least 3 days old