### PR TITLE
fix(repository): synchronize CredentialStore reads via atomic snapshot

### DIFF
--- a/internal/repository/credentials/credentials.go
+++ b/internal/repository/credentials/credentials.go
@@ -7,6 +7,7 @@ import (
 	"slices"
 	"strings"
 	"sync"
+	"sync/atomic"
 	"time"
 
 	configv1alpha1 "github.com/padok-team/burrito/api/v1alpha1"
@@ -22,13 +23,22 @@ const (
 	CredentialsType       = "credentials.burrito.tf/repository"
 )
 
+// credentialsSnapshot is an immutable view of the cached credentials. Each
+// refresh builds a brand new snapshot and swaps it in atomically, so readers
+// never mutate or block on it — they just load whatever snapshot is current.
+type credentialsSnapshot struct {
+	shared     []*SharedCredential
+	repository []*RepositoryCredential
+	updatedAt  time.Time
+}
+
 type CredentialStore struct {
 	TTL time.Duration
-	mu  sync.Mutex
 	client.Client
-	sharedCredentials     []*SharedCredential
-	repositoryCredentials []*RepositoryCredential
-	lastUpdate            time.Time
+	current atomic.Pointer[credentialsSnapshot]
+	// refreshMu serializes refreshes so that concurrent stale readers trigger
+	// a single API call instead of one each. It is never held by readers.
+	refreshMu sync.Mutex
 }
 
 func NewCredentialStore(client client.Client, ttl time.Duration) *CredentialStore {
@@ -36,32 +46,53 @@ func NewCredentialStore(client client.Client, ttl time.Duration) *CredentialStor
 		Client: client,
 		TTL:    ttl,
 	}
+	credentialStore.current.Store(&credentialsSnapshot{})
 	return credentialStore
 }
 
 func (s *CredentialStore) GetAllCredentials() ([]*SharedCredential, []*RepositoryCredential) {
-	if time.Since(s.lastUpdate) >= s.TTL {
-		err := s.updateCredentials()
-		if err != nil {
-			log.Errorf("Failed to update credentials: %v", err)
-		}
-	}
-	return s.sharedCredentials, s.repositoryCredentials
+	snapshot := s.refreshIfNeeded()
+	return snapshot.shared, snapshot.repository
 }
 
-func (s *CredentialStore) updateCredentials() error {
-	s.mu.Lock()
-	defer s.mu.Unlock()
-	// Skip if the last update was less than the TTL
-	if time.Since(s.lastUpdate) < s.TTL {
-		return nil
+// refreshIfNeeded returns the current snapshot, refreshing it first if it is
+// older than the TTL. The common case (fresh snapshot) never takes a lock.
+func (s *CredentialStore) refreshIfNeeded() *credentialsSnapshot {
+	snapshot := s.current.Load()
+	if time.Since(snapshot.updatedAt) < s.TTL {
+		return snapshot
 	}
+
+	s.refreshMu.Lock()
+	defer s.refreshMu.Unlock()
+	// Re-check: another goroutine may have refreshed while we waited for the lock.
+	snapshot = s.current.Load()
+	if time.Since(snapshot.updatedAt) < s.TTL {
+		return snapshot
+	}
+
+	next, err := s.buildSnapshot(snapshot)
+	if err != nil {
+		log.Errorf("failed to update credentials: %v", err)
+	}
+	s.current.Store(next)
+	return next
+}
+
+// buildSnapshot lists secrets and returns the next snapshot. On a list error
+// it keeps the previous credentials but still bumps updatedAt, so a failing
+// API call is retried after TTL instead of on every single request.
+func (s *CredentialStore) buildSnapshot(previous *credentialsSnapshot) (*credentialsSnapshot, error) {
+	next := &credentialsSnapshot{
+		shared:     previous.shared,
+		repository: previous.repository,
+	}
+	defer func() { next.updatedAt = time.Now() }()
 
 	sharedSecrets := &corev1.SecretList{}
 	err := s.List(context.Background(), sharedSecrets, client.MatchingFields{"type": SharedCredentialsType})
 	if err != nil {
-		s.lastUpdate = time.Now()
-		return err
+		return next, err
 	}
 	var sharedCredentials []*SharedCredential
 	for _, secret := range sharedSecrets.Items {
@@ -76,8 +107,7 @@ func (s *CredentialStore) updateCredentials() error {
 	repositorySecrets := &corev1.SecretList{}
 	err = s.List(context.Background(), repositorySecrets, client.MatchingFields{"type": CredentialsType})
 	if err != nil {
-		s.lastUpdate = time.Now()
-		return err
+		return next, err
 	}
 	var repositoryCredentials []*RepositoryCredential
 	for _, secret := range repositorySecrets.Items {
@@ -89,29 +119,22 @@ func (s *CredentialStore) updateCredentials() error {
 		repositoryCredentials = append(repositoryCredentials, tmp)
 	}
 
-	s.repositoryCredentials = repositoryCredentials
-	s.sharedCredentials = sharedCredentials
-	s.lastUpdate = time.Now()
-
-	return nil
+	next.shared = sharedCredentials
+	next.repository = repositoryCredentials
+	return next, nil
 }
 
 // Returns the credentials for a given repository. If a specific repository credential is found, it will be returned.
 // If not, the most specific shared credential that matches the repository will be returned.
 func (s *CredentialStore) GetCredentials(repository *configv1alpha1.TerraformRepository) (*Credential, error) {
-	if time.Since(s.lastUpdate) >= s.TTL {
-		err := s.updateCredentials()
-		if err != nil {
-			log.Errorf("failed to update credentials: %v", err)
-		}
-	}
-	for _, repositoryCredentials := range s.repositoryCredentials {
+	snapshot := s.refreshIfNeeded()
+	for _, repositoryCredentials := range snapshot.repository {
 		if repositoryCredentials.Matches(repository) {
 			return &repositoryCredentials.Credential, nil
 		}
 	}
 	var sharedCredential *SharedCredential
-	for _, tmp := range s.sharedCredentials {
+	for _, tmp := range snapshot.shared {
 		isAllowed := tmp.IsAllowed(repository)
 		matches := tmp.Matches(repository)
 		if isAllowed && matches {

--- a/internal/repository/credentials/credentials_test.go
+++ b/internal/repository/credentials/credentials_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"path/filepath"
+	"sync"
 	"testing"
 	"time"
 
@@ -128,6 +129,34 @@ var _ = Describe("Credentials", func() {
 				Expect(credentials.Username).To(Equal("username-match-1"))
 				Expect(credentials.Password).To(Equal("password-match-1"))
 			})
+		})
+	})
+	Describe("Concurrent access", Ordered, func() {
+		It("should not race when GetCredentials/GetAllCredentials run concurrently with a refresh", func() {
+			// TTL of 0 forces every call to attempt a refresh, so reads
+			// (GetCredentials/GetAllCredentials) and the refresh they trigger
+			// are guaranteed to overlap across goroutines. Run with `go test -race`.
+			store := credentials.NewCredentialStore(k8sClient, 0)
+			repository := &configv1alpha1.TerraformRepository{}
+			err := k8sClient.Get(context.TODO(), types.NamespacedName{
+				Name:      "repository-secret-present",
+				Namespace: "default",
+			}, repository)
+			Expect(err).NotTo(HaveOccurred())
+
+			var wg sync.WaitGroup
+			for i := 0; i < 50; i++ {
+				wg.Add(2)
+				go func() {
+					defer wg.Done()
+					_, _ = store.GetCredentials(repository)
+				}()
+				go func() {
+					defer wg.Done()
+					store.GetAllCredentials()
+				}()
+			}
+			wg.Wait()
 		})
 	})
 })


### PR DESCRIPTION
## What

`CredentialStore.GetAllCredentials()` and `GetCredentials()` read `lastUpdate`, `sharedCredentials`, and `repositoryCredentials` without synchronization, while `updateCredentials()` writes those same fields under `s.mu`. Concurrent webhook requests (`GetAllCredentials` via the webhook HTTP handler) and reconciles (`GetCredentials`) can race against a refresh — confirmed with `go test -race`.

## Fix

Alternative to the mutex-based approach: instead of adding locking around the reads, the mutable fields are replaced with an immutable `credentialsSnapshot` (`shared`, `repository`, `updatedAt`) swapped in atomically via `atomic.Pointer[credentialsSnapshot]`.

- Readers (`GetAllCredentials`, `GetCredentials`) call `refreshIfNeeded()`, which loads the current snapshot with a lock-free `Load()`. If it's still fresh, it's returned as-is — the hot path never takes a lock.
- If stale, a `refreshMu` mutex (only ever taken on the refresh path, never by readers) serializes refreshes with a double-checked staleness check, so concurrent stale readers trigger a single API call instead of one each.
- `buildSnapshot()` lists the secrets and builds the next snapshot. On a list error it keeps the previous credentials but still bumps `updatedAt`, matching the existing retry-after-TTL behavior on API failures.

No behavior change: same lazy, TTL-based refresh semantics as before, same matching logic in `GetCredentials`. This only removes the unsynchronized-read window.

## Testing

- Added a `Concurrent access` spec to the existing Ginkgo suite in `internal/repository/credentials/credentials_test.go`, running 50 pairs of goroutines against `GetCredentials`/`GetAllCredentials` with `TTL: 0` (forces a refresh attempt on every call, guaranteeing overlap with the refresh path).
- `go test -race ./internal/repository/credentials/...`: 6/6 specs pass, 0 races.
- Verified the same spec reproduces the original race (multiple `WARNING: DATA RACE` reports) when run against the pre-fix code.
- `go build ./...` and `go vet ./internal/repository/...` are clean.

Closes #963