### PR TITLE
chore: align root pnpm minimumReleaseAge with renovate and ui config

### DIFF
--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,3 +1,3 @@
-minimumReleaseAge: 10080 # 7 days
+minimumReleaseAge: 4320 # 3 days, aligned with renovate.json's minimumReleaseAge
 trustPolicy: no-downgrade
 ignoreScripts: true


### PR DESCRIPTION
## Summary
- `ui/pnpm-workspace.yaml` and `renovate.json` were already updated to a 3-day minimum release age, but the root `pnpm-workspace.yaml` was left at 7 days (10080 minutes).
- Bump root `minimumReleaseAge` from `10080` (7 days) to `4320` (3 days) to match.

## Test plan
- [ ] Confirm `pnpm install` at the repo root respects the updated `minimumReleaseAge`