### PR TITLE
fix(repository): synchronize CredentialStore reads via atomic snapshot

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -119,8 +119,9 @@ clean-compose: ## Run docker-compose down.
 	docker compose -f internal/e2e/docker-compose.yml down --remove-orphans --volumes
 
 .PHONY: test
+# -race is required for the concurrency specs to be able to fail at all.
 test: manifests generate fmt vet envtest compose ## Run tests.
-	KUBEBUILDER_ASSETS="$(shell $(ENVTEST) use $(ENVTEST_K8S_VERSION) --bin-dir $(LOCALBIN) -p path)" go test ./... -coverprofile cover.out
+	KUBEBUILDER_ASSETS="$(shell $(ENVTEST) use $(ENVTEST_K8S_VERSION) --bin-dir $(LOCALBIN) -p path)" go test -race ./... -coverprofile cover.out
 	$(MAKE) clean-compose
 
 NEW_VERSION := $(shell date +%s)

--- a/internal/repository/credentials/credentials.go
+++ b/internal/repository/credentials/credentials.go
@@ -7,6 +7,7 @@ import (
 	"slices"
 	"strings"
 	"sync"
+	"sync/atomic"
 	"time"
 
 	configv1alpha1 "github.com/padok-team/burrito/api/v1alpha1"
@@ -22,13 +23,22 @@ const (
 	CredentialsType       = "credentials.burrito.tf/repository"
 )
 
+// credentialsSnapshot is an immutable view of the cached credentials. Each
+// refresh builds a brand new snapshot and swaps it in atomically, so readers
+// never mutate or block on it — they just load whatever snapshot is current.
+type credentialsSnapshot struct {
+	shared     []*SharedCredential
+	repository []*RepositoryCredential
+	updatedAt  time.Time
+}
+
 type CredentialStore struct {
 	TTL time.Duration
-	mu  sync.Mutex
 	client.Client
-	sharedCredentials     []*SharedCredential
-	repositoryCredentials []*RepositoryCredential
-	lastUpdate            time.Time
+	current atomic.Pointer[credentialsSnapshot]
+	// refreshMu serializes refreshes so that concurrent stale readers trigger
+	// a single API call instead of one each. It is never held by readers.
+	refreshMu sync.Mutex
 }
 
 func NewCredentialStore(client client.Client, ttl time.Duration) *CredentialStore {
@@ -36,32 +46,64 @@ func NewCredentialStore(client client.Client, ttl time.Duration) *CredentialStor
 		Client: client,
 		TTL:    ttl,
 	}
+	credentialStore.current.Store(&credentialsSnapshot{})
 	return credentialStore
 }
 
 func (s *CredentialStore) GetAllCredentials() ([]*SharedCredential, []*RepositoryCredential) {
-	if time.Since(s.lastUpdate) >= s.TTL {
-		err := s.updateCredentials()
-		if err != nil {
-			log.Errorf("Failed to update credentials: %v", err)
-		}
-	}
-	return s.sharedCredentials, s.repositoryCredentials
+	snapshot := s.refreshIfNeeded()
+	return snapshot.shared, snapshot.repository
 }
 
-func (s *CredentialStore) updateCredentials() error {
-	s.mu.Lock()
-	defer s.mu.Unlock()
-	// Skip if the last update was less than the TTL
-	if time.Since(s.lastUpdate) < s.TTL {
-		return nil
+// refreshIfNeeded returns the current snapshot, refreshing it first if it is
+// older than the TTL. The common case (fresh snapshot) never takes a lock.
+func (s *CredentialStore) refreshIfNeeded() *credentialsSnapshot {
+	snapshot := s.load()
+	if time.Since(snapshot.updatedAt) < s.TTL {
+		return snapshot
+	}
+
+	s.refreshMu.Lock()
+	defer s.refreshMu.Unlock()
+	// Re-check: another goroutine may have refreshed while we waited for the lock.
+	snapshot = s.load()
+	if time.Since(snapshot.updatedAt) < s.TTL {
+		return snapshot
+	}
+
+	next, err := s.buildSnapshot(snapshot)
+	if err != nil {
+		log.Errorf("failed to update credentials: %v", err)
+	}
+	// Stamp the snapshot even when the refresh failed, so a failing API call is
+	// retried after the TTL instead of on every single request.
+	next.updatedAt = time.Now()
+	s.current.Store(next)
+	return next
+}
+
+// load returns the current snapshot, never nil. A CredentialStore built as a
+// struct literal instead of through NewCredentialStore has no snapshot yet.
+func (s *CredentialStore) load() *credentialsSnapshot {
+	if snapshot := s.current.Load(); snapshot != nil {
+		return snapshot
+	}
+	return &credentialsSnapshot{}
+}
+
+// buildSnapshot lists secrets and returns the next snapshot. On a list error it
+// returns a snapshot carrying the previous credentials, so a failed refresh
+// keeps serving the last known-good values instead of dropping them.
+func (s *CredentialStore) buildSnapshot(previous *credentialsSnapshot) (*credentialsSnapshot, error) {
+	next := &credentialsSnapshot{
+		shared:     previous.shared,
+		repository: previous.repository,
 	}
 
 	sharedSecrets := &corev1.SecretList{}
 	err := s.List(context.Background(), sharedSecrets, client.MatchingFields{"type": SharedCredentialsType})
 	if err != nil {
-		s.lastUpdate = time.Now()
-		return err
+		return next, err
 	}
 	var sharedCredentials []*SharedCredential
 	for _, secret := range sharedSecrets.Items {
@@ -76,8 +118,7 @@ func (s *CredentialStore) updateCredentials() error {
 	repositorySecrets := &corev1.SecretList{}
 	err = s.List(context.Background(), repositorySecrets, client.MatchingFields{"type": CredentialsType})
 	if err != nil {
-		s.lastUpdate = time.Now()
-		return err
+		return next, err
 	}
 	var repositoryCredentials []*RepositoryCredential
 	for _, secret := range repositorySecrets.Items {
@@ -89,29 +130,22 @@ func (s *CredentialStore) updateCredentials() error {
 		repositoryCredentials = append(repositoryCredentials, tmp)
 	}
 
-	s.repositoryCredentials = repositoryCredentials
-	s.sharedCredentials = sharedCredentials
-	s.lastUpdate = time.Now()
-
-	return nil
+	next.shared = sharedCredentials
+	next.repository = repositoryCredentials
+	return next, nil
 }
 
 // Returns the credentials for a given repository. If a specific repository credential is found, it will be returned.
 // If not, the most specific shared credential that matches the repository will be returned.
 func (s *CredentialStore) GetCredentials(repository *configv1alpha1.TerraformRepository) (*Credential, error) {
-	if time.Since(s.lastUpdate) >= s.TTL {
-		err := s.updateCredentials()
-		if err != nil {
-			log.Errorf("failed to update credentials: %v", err)
-		}
-	}
-	for _, repositoryCredentials := range s.repositoryCredentials {
+	snapshot := s.refreshIfNeeded()
+	for _, repositoryCredentials := range snapshot.repository {
 		if repositoryCredentials.Matches(repository) {
 			return &repositoryCredentials.Credential, nil
 		}
 	}
 	var sharedCredential *SharedCredential
-	for _, tmp := range s.sharedCredentials {
+	for _, tmp := range snapshot.shared {
 		isAllowed := tmp.IsAllowed(repository)
 		matches := tmp.Matches(repository)
 		if isAllowed && matches {

--- a/internal/repository/credentials/credentials_test.go
+++ b/internal/repository/credentials/credentials_test.go
@@ -4,6 +4,8 @@ import (
 	"context"
 	"fmt"
 	"path/filepath"
+	"sync"
+	"sync/atomic"
 	"testing"
 	"time"
 
@@ -11,12 +13,17 @@ import (
 	. "github.com/onsi/gomega"
 
 	configv1alpha1 "github.com/padok-team/burrito/api/v1alpha1"
+	"github.com/padok-team/burrito/internal/annotations"
 	"github.com/padok-team/burrito/internal/repository/credentials"
 	utils "github.com/padok-team/burrito/internal/testing"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/client-go/kubernetes/scheme"
 	"k8s.io/client-go/rest"
 	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 	"sigs.k8s.io/controller-runtime/pkg/envtest"
 	logf "sigs.k8s.io/controller-runtime/pkg/log"
 	"sigs.k8s.io/controller-runtime/pkg/log/zap"
@@ -31,6 +38,75 @@ func TestCredentials(t *testing.T) {
 	RegisterFailHandler(Fail)
 
 	RunSpecs(t, "Credentials Suite")
+}
+
+const concurrentRepositoryUrl = "https://github.com/padok-team/burrito"
+
+// listCountingClient counts List calls so specs can assert how many refreshes a
+// burst of concurrent readers actually triggered.
+type listCountingClient struct {
+	client.Client
+	lists atomic.Int64
+}
+
+func (c *listCountingClient) List(ctx context.Context, list client.ObjectList, opts ...client.ListOption) error {
+	c.lists.Add(1)
+	return c.Client.List(ctx, list, opts...)
+}
+
+// newConcurrentTestClient builds an in-memory client holding one repository and
+// one shared credential, both matching concurrentTestRepository(). The
+// concurrency specs drive tens of thousands of List calls, which is far more
+// than the envtest API server used by the rest of this suite can serve.
+func newConcurrentTestClient() *listCountingClient {
+	testScheme := runtime.NewScheme()
+	Expect(corev1.AddToScheme(testScheme)).To(Succeed())
+
+	repositorySecret := &corev1.Secret{
+		ObjectMeta: metav1.ObjectMeta{Name: "repo-creds", Namespace: "default"},
+		Type:       corev1.SecretType(credentials.CredentialsType),
+		Data: map[string][]byte{
+			"provider": []byte("github"),
+			"url":      []byte(concurrentRepositoryUrl),
+			"username": []byte("repository-user"),
+			"password": []byte("repository-password"),
+		},
+	}
+	sharedSecret := &corev1.Secret{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:        "shared-creds",
+			Namespace:   "default",
+			Annotations: map[string]string{annotations.AllowedTenants: "default"},
+		},
+		Type: corev1.SecretType(credentials.SharedCredentialsType),
+		Data: map[string][]byte{
+			"provider": []byte("github"),
+			"url":      []byte("https://github.com/padok-team"),
+			"username": []byte("shared-user"),
+			"password": []byte("shared-password"),
+		},
+	}
+
+	return &listCountingClient{
+		Client: fake.NewClientBuilder().
+			WithScheme(testScheme).
+			WithObjects(repositorySecret, sharedSecret).
+			WithIndex(&corev1.Secret{}, "type", func(obj client.Object) []string {
+				return []string{string(obj.(*corev1.Secret).Type)}
+			}).
+			Build(),
+	}
+}
+
+func concurrentTestRepository() *configv1alpha1.TerraformRepository {
+	return &configv1alpha1.TerraformRepository{
+		ObjectMeta: metav1.ObjectMeta{Name: "repo", Namespace: "default"},
+		Spec: configv1alpha1.TerraformRepositorySpec{
+			Repository: configv1alpha1.TerraformRepositoryRepository{
+				Url: concurrentRepositoryUrl,
+			},
+		},
+	}
 }
 
 var _ = BeforeSuite(func() {
@@ -128,6 +204,82 @@ var _ = Describe("Credentials", func() {
 				Expect(credentials.Username).To(Equal("username-match-1"))
 				Expect(credentials.Password).To(Equal("password-match-1"))
 			})
+		})
+	})
+	Describe("Concurrent access", func() {
+		const (
+			readers    = 32
+			iterations = 100
+		)
+
+		It("should serve consistent credentials while refreshing concurrently", func() {
+			// A TTL of 0 makes every call refresh, so reads
+			// (GetCredentials/GetAllCredentials) and the refresh they trigger are
+			// guaranteed to overlap across goroutines. The counters below fail on a
+			// partially observed refresh even without the race detector; run with
+			// `go test -race` to also catch unsynchronized access itself.
+			store := credentials.NewCredentialStore(newConcurrentTestClient(), 0)
+			repository := concurrentTestRepository()
+
+			var lookupErrors, unexpectedCredential, unexpectedCounts atomic.Int64
+			var wg sync.WaitGroup
+			for i := 0; i < readers; i++ {
+				wg.Add(2)
+				go func() {
+					defer wg.Done()
+					for j := 0; j < iterations; j++ {
+						credential, err := store.GetCredentials(repository)
+						if err != nil {
+							lookupErrors.Add(1)
+							continue
+						}
+						// The repository credential is more specific than the shared
+						// one, so it must win on every single call.
+						if credential.Username != "repository-user" {
+							unexpectedCredential.Add(1)
+						}
+					}
+				}()
+				go func() {
+					defer wg.Done()
+					for j := 0; j < iterations; j++ {
+						shared, repos := store.GetAllCredentials()
+						if len(shared) != 1 || len(repos) != 1 {
+							unexpectedCounts.Add(1)
+						}
+					}
+				}()
+			}
+			wg.Wait()
+
+			Expect(lookupErrors.Load()).To(BeZero(), "GetCredentials stopped matching the repository credential")
+			Expect(unexpectedCredential.Load()).To(BeZero(), "GetCredentials returned a credential from an incomplete snapshot")
+			Expect(unexpectedCounts.Load()).To(BeZero(), "GetAllCredentials returned an incomplete snapshot")
+		})
+
+		It("should refresh once when concurrent readers find the cache stale", func() {
+			// Cold store, long TTL: every reader below sees a stale cache, but only
+			// one of them should reach the API. A single refresh is two List calls
+			// (shared secrets, then repository secrets).
+			concurrentClient := newConcurrentTestClient()
+			store := credentials.NewCredentialStore(concurrentClient, time.Hour)
+			repository := concurrentTestRepository()
+
+			var wg sync.WaitGroup
+			for i := 0; i < readers; i++ {
+				wg.Add(2)
+				go func() {
+					defer wg.Done()
+					_, _ = store.GetCredentials(repository)
+				}()
+				go func() {
+					defer wg.Done()
+					store.GetAllCredentials()
+				}()
+			}
+			wg.Wait()
+
+			Expect(concurrentClient.lists.Load()).To(BeEquivalentTo(2), "concurrent stale readers should share a single refresh")
 		})
 	})
 })


### PR DESCRIPTION
## What

`CredentialStore.GetAllCredentials()` and `GetCredentials()` read `lastUpdate`, `sharedCredentials` and `repositoryCredentials` without synchronization, while `updateCredentials()` writes those same fields under `s.mu`. A webhook request (`GetAllCredentials`, one goroutine per HTTP request) or a reconcile (`GetCredentials`, concurrent across controller-runtime workers) can therefore observe a partially applied refresh.

> [!NOTE]
> This is a **fourth** PR against #963, after #964, #976 (closed as duplicate) and #1069. It is not an independent attempt: it takes #1069's implementation and #964's test approach, on the conclusion that #1069 has the better fix and #964 the better test. Maintainers should pick one of these deliberately and close the rest — please don't merge this alongside #964 or #1069.

## Fix

Replace the mutable fields with an immutable `credentialsSnapshot` (`shared`, `repository`, `updatedAt`) swapped in atomically via `atomic.Pointer` — the approach from #1069.

- Readers call `refreshIfNeeded()`, which loads the current snapshot with a lock-free `Load()`. If it's still fresh it is returned as-is, so the hot path never takes a lock.
- If stale, `refreshMu` serializes refreshes with a double-checked staleness test, so concurrent stale readers trigger a single API call instead of one each. `refreshMu` is never held by a reader.
- `buildSnapshot()` lists the secrets and builds the next snapshot.

### Why this over adding `RLock` to the readers (#964)

Both close the race. The difference is what happens to readers *during* a refresh:

- Under an `RWMutex`, `updateCredentials()` holds the **write** lock across both `s.List(...)` calls, so every reader blocks for the duration — including readers whose data is already fresh. `sync.RWMutex` also blocks new `RLock` acquisitions once a writer is waiting, so a reader can stall on a refresh that hasn't started yet.
- The webhook's store is built from `client.New(...)` in `internal/server/server.go` — an **uncached, direct** client. Each refresh is two live API-server round trips, and neither `List` has a timeout (`context.Background()`). Under the mutex approach a slow or hung refresh takes the whole read path with it; here it only blocks other *stale* readers, and fresh callers keep serving the last known-good snapshot.
- Moving `updatedAt` into the snapshot makes the staleness check and the data read a **single** atomic operation, and makes "shared and repository credentials come from the same refresh generation" a structural invariant rather than something that depends on every present and future accessor holding a lock across both reads.

The cost is a larger diff for a synchronization bug — that trade-off is the reviewer's call.

### Changes on top of #1069

- `updatedAt` is stamped in `refreshIfNeeded()` right before `Store()`, instead of via `defer func() { next.updatedAt = time.Now() }()` inside `buildSnapshot`. That worked (mutation through the returned pointer), but it relied on the reader spotting it; `buildSnapshot` is now a pure builder and the "bump even on failure" rule lives at the single place that publishes.
- Added `load()` so both snapshot loads are nil-safe. `current` is only initialized in `NewCredentialStore`, so `&CredentialStore{Client: c, TTL: t}` built as a struct literal — valid before this change — would otherwise panic on an exported type.

**No behaviour change** otherwise: same lazy TTL refresh, same matching logic in `GetCredentials`, and a failed `List` still keeps the previous credentials while stamping `updatedAt`, so the retry waits for the TTL instead of firing on every request. Partial failure (shared list succeeds, repository list fails) also behaves as before.

## Testing

Two specs added to the existing Ginkgo suite, using a fake client rather than the suite's envtest `k8sClient` — the approach from #964:

- **Consistency under concurrent refresh** — 32 readers × 100 iterations × 2 goroutines at `TTL: 0`, so every call refreshes and reads are guaranteed to overlap with it. That is ~12,800 `List` calls, which is why the fake client matters; against a real API server this spec would take minutes. Assertions are accumulated in atomic counters and checked after `wg.Wait()`, so they run in the spec goroutine and don't need `GinkgoRecover`.
- **Single-flight refresh** — cold store, `TTL: time.Hour`, 64 concurrent readers, asserting exactly 2 `List` calls (one refresh = shared secrets + repository secrets) via a counting client wrapper. To be clear: this spec also passes on the pre-fix code. It is forward protection for a property nothing covered, not a repro of #963.

### `-race` in `make test`

`make test` was `go test ./... -coverprofile cover.out` — **no `-race`** — and CI runs `make test`. A concurrency spec whose only failure mode is the race detector therefore passes on the buggy code too, which is why the first spec above asserts observable state rather than relying on `-race` alone.

`-race` is added to the test target so the unsynchronized access itself can also be caught. **Reviewer beware:** I have not verified that every other package is race-clean under it, so this may surface pre-existing races elsewhere. If it does, the narrow fallback is a separate `test-race` target scoped to `./internal/repository/credentials/...` as its own CI step, rather than dropping the flag.

## Verification

Verified statically only — `gofmt` clean on the changed package, and the `client/fake` `WithIndex` signature and `TerraformRepositorySpec` field names checked against controller-runtime v0.24.1 and `api/v1alpha1`. I did **not** run `make test`, `go build`, or `go vet` locally; CI is the gate. `npx commitlint` could not run in this environment (Node v22 available, repo requires v26), so the commit message conforms to `config-conventional` by inspection only.

## Credit

The implementation is @DjinnS's from #1069. The test strategy — fake client, real assertions, high iteration count — is @drawliin's from #964, who also filed #963. @vjymisal0 independently reached the same fix in #976. All three are on the commit as co-authors.

Closes #963
