### PR TITLE
feat(server): add OIDC claim-based authorization

### DIFF
--- a/deploy/charts/burrito/values.yaml
+++ b/deploy/charts/burrito/values.yaml
@@ -89,6 +89,10 @@ config:
           - "openid"
           - "profile"
           - "email"
+        # -- Map of claim name to allowed values; a user is authorized only if the ID token
+        # satisfies every listed claim (e.g. {"groups": ["burrito-admins"]}). Empty means no
+        # restriction: any authenticated user is authorized (default).
+        requiredClaims: {}
       session:
         # -- Session max age in seconds, after which the session will expire
         maxAge: 86400

--- a/docs/operator-manual/user-authentication.md
+++ b/docs/operator-manual/user-authentication.md
@@ -65,6 +65,9 @@ config:
           - "openid"
           - "profile"
           - "email"
+        requiredClaims:
+          groups:
+            - "burrito-admins"
 ...
 server:
   deployment:
@@ -80,6 +83,7 @@ server:
 | `clientId`                | Registered client ID                                                     |
 | `redirectUrl`             | Callback URL for OIDC (must match the one registered with your provider) |
 | `scopes`                  | OIDC scopes to request                                                   |
+| `requiredClaims`          | Map of claim name to allowed values, used to authorize users (see below) |
 
 ## Disabling Authentication
 
@@ -87,4 +91,23 @@ If both Basic Authentication and OIDC are disabled, the Burrito server will be p
 
 ### Authorization
 
-For the moment, Burrito does not implement authorization mechanisms. All users that are able to authenticate with the configured OIDC provider will be able to access the Burrito UI.
+By default, any user able to authenticate with the configured OIDC provider is authorized to
+access the Burrito UI. To restrict access, set `requiredClaims` to a map of claim name to the
+list of values that satisfy it:
+
+```yaml
+server:
+  oidc:
+    requiredClaims:
+      groups:
+        - "burrito-admins"
+        - "platform-team"
+```
+
+A user is authorized only if **every** configured claim has a matching value on their ID
+token — a claim is satisfied if its value (a plain string, or an array such as `groups`)
+contains at least one of the allowed values. Users whose token doesn't satisfy the required
+claims are redirected back to the login page with an error.
+
+This is an all-or-nothing gate on the whole Burrito instance — there is currently no
+per-tenant/per-namespace authorization based on claims.

--- a/internal/burrito/config/config.go
+++ b/internal/burrito/config/config.go
@@ -132,6 +132,10 @@ type OIDCConfig struct {
 	ClientSecret string   `mapstructure:"clientSecret"`
 	RedirectURL  string   `mapstructure:"redirectUrl"`
 	Scopes       []string `mapstructure:"scopes"`
+	// RequiredClaims maps a claim name to the list of values that satisfy it. A user is
+	// authorized only if every configured claim has a matching value on the ID token. Empty
+	// or absent means no restriction.
+	RequiredClaims map[string][]string `mapstructure:"requiredClaims"`
 }
 
 type BasicAuthConfig struct {

--- a/internal/server/auth/oauth/oauth.go
+++ b/internal/server/auth/oauth/oauth.go
@@ -23,6 +23,7 @@ type OAuthAuthHandlers struct {
 	OAuth2Config    *oauth2.Config
 	SessionCookie   string
 	LoginHTTPMethod string
+	RequiredClaims  map[string][]string
 }
 
 func New(c *config.Config, ctx context.Context, cl client.Client, sessionCookie string) (*OAuthAuthHandlers, error) {
@@ -44,6 +45,7 @@ func New(c *config.Config, ctx context.Context, cl client.Client, sessionCookie 
 	}
 	oauth.SessionCookie = sessionCookie
 	oauth.LoginHTTPMethod = http.MethodGet
+	oauth.RequiredClaims = c.Server.OIDC.RequiredClaims
 
 	return oauth, nil
 }
@@ -119,6 +121,18 @@ func (o *OAuthAuthHandlers) HandleCallback(c echo.Context) error {
 		return echo.NewHTTPError(http.StatusInternalServerError, "Failed to extract claims")
 	}
 
+	// Extract raw claims to check arbitrary/custom claims (e.g. groups, roles) against
+	// RequiredClaims, which the typed struct above does not capture.
+	var rawClaims map[string]interface{}
+	if err := idToken.Claims(&rawClaims); err != nil {
+		return echo.NewHTTPError(http.StatusInternalServerError, "Failed to extract claims")
+	}
+
+	if !claimsSatisfyRequirements(rawClaims, o.RequiredClaims) {
+		log.Warnf("OIDC login denied for subject %s: required claims not satisfied", claims.Sub)
+		return c.Redirect(http.StatusTemporaryRedirect, "/login?error=access_denied")
+	}
+
 	// Upgrade session cookie to SameSite=Strict after successful login
 	sess.Options.SameSite = http.SameSiteStrictMode
 
@@ -134,6 +148,54 @@ func (o *OAuthAuthHandlers) HandleCallback(c echo.Context) error {
 
 	// Redirect to layers page
 	return c.Redirect(http.StatusTemporaryRedirect, "/layers")
+}
+
+// claimsSatisfyRequirements checks that, for every claim name in required, the ID token's
+// claim value (a string, or an array of strings such as a "groups" claim) contains at least
+// one of the allowed values. All required claims must be satisfied. An empty or nil required
+// map always passes.
+func claimsSatisfyRequirements(claims map[string]interface{}, required map[string][]string) bool {
+	for claimName, allowedValues := range required {
+		value, ok := claims[claimName]
+		if !ok {
+			return false
+		}
+
+		if !containsAny(claimValues(value), allowedValues) {
+			return false
+		}
+	}
+	return true
+}
+
+// claimValues normalizes a decoded claim value into a slice of strings, supporting both a
+// single string claim and an array claim (e.g. "groups").
+func claimValues(value interface{}) []string {
+	switch v := value.(type) {
+	case string:
+		return []string{v}
+	case []interface{}:
+		values := make([]string, 0, len(v))
+		for _, item := range v {
+			if s, ok := item.(string); ok {
+				values = append(values, s)
+			}
+		}
+		return values
+	default:
+		return nil
+	}
+}
+
+func containsAny(values []string, allowed []string) bool {
+	for _, v := range values {
+		for _, a := range allowed {
+			if v == a {
+				return true
+			}
+		}
+	}
+	return false
 }
 
 func generateRandomString(length int) string {

--- a/internal/server/auth/oauth/oauth_test.go
+++ b/internal/server/auth/oauth/oauth_test.go
@@ -1,0 +1,86 @@
+package oauth
+
+import "testing"
+
+func TestClaimsSatisfyRequirements(t *testing.T) {
+	tests := []struct {
+		name     string
+		claims   map[string]interface{}
+		required map[string][]string
+		want     bool
+	}{
+		{
+			name:     "no required claims always passes",
+			claims:   map[string]interface{}{},
+			required: nil,
+			want:     true,
+		},
+		{
+			name:     "missing claim fails",
+			claims:   map[string]interface{}{"email": "user@example.com"},
+			required: map[string][]string{"groups": {"burrito-admins"}},
+			want:     false,
+		},
+		{
+			name:     "string claim matches",
+			claims:   map[string]interface{}{"role": "admin"},
+			required: map[string][]string{"role": {"admin", "operator"}},
+			want:     true,
+		},
+		{
+			name:     "string claim mismatch",
+			claims:   map[string]interface{}{"role": "viewer"},
+			required: map[string][]string{"role": {"admin", "operator"}},
+			want:     false,
+		},
+		{
+			name: "array claim matches one of the allowed values",
+			claims: map[string]interface{}{
+				"groups": []interface{}{"engineering", "burrito-admins"},
+			},
+			required: map[string][]string{"groups": {"burrito-admins"}},
+			want:     true,
+		},
+		{
+			name: "array claim mismatch",
+			claims: map[string]interface{}{
+				"groups": []interface{}{"engineering", "sales"},
+			},
+			required: map[string][]string{"groups": {"burrito-admins"}},
+			want:     false,
+		},
+		{
+			name: "multiple required claims must all be satisfied",
+			claims: map[string]interface{}{
+				"role":   "admin",
+				"groups": []interface{}{"engineering"},
+			},
+			required: map[string][]string{
+				"role":   {"admin"},
+				"groups": {"burrito-admins"},
+			},
+			want: false,
+		},
+		{
+			name: "multiple required claims all satisfied",
+			claims: map[string]interface{}{
+				"role":   "admin",
+				"groups": []interface{}{"burrito-admins"},
+			},
+			required: map[string][]string{
+				"role":   {"admin"},
+				"groups": {"burrito-admins"},
+			},
+			want: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := claimsSatisfyRequirements(tt.claims, tt.required)
+			if got != tt.want {
+				t.Errorf("claimsSatisfyRequirements() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}

--- a/ui/src/pages/Login.tsx
+++ b/ui/src/pages/Login.tsx
@@ -1,5 +1,5 @@
 import React, { useContext, useState } from 'react';
-import { useNavigate } from 'react-router';
+import { useNavigate, useSearchParams } from 'react-router';
 import { useQuery, useMutation } from '@tanstack/react-query';
 
 import { ThemeContext } from '@/contexts/ThemeContext';
@@ -22,6 +22,8 @@ import SSOButton from '@/components/buttons/SSOButton';
 const Login: React.FC = () => {
   const { theme } = useContext(ThemeContext);
   const navigate = useNavigate();
+  const [searchParams] = useSearchParams();
+  const accessDenied = searchParams.get('error') === 'access_denied';
   // Fetch supported auth method from server
   const {
     data: authType,
@@ -104,6 +106,13 @@ const Login: React.FC = () => {
             </span>
           </div>
           <div className="flex flex-col items-center justify-center gap-8 w-full">
+            {accessDenied && (
+              <div
+                className={`text-sm ${theme === 'light' ? 'text-red-600' : 'text-red-400'}`}
+              >
+                You don&apos;t have permission to access this Burrito instance.
+              </div>
+            )}
             {isBasicAuth ? (
               <form
                 onSubmit={handleLogin}


### PR DESCRIPTION
## Summary
- Adds `server.oidc.requiredClaims` (map of claim name → allowed values) to gate dashboard access on the OIDC ID token's claims, closing the phase-1 gap in #904 ("Burrito does not implement authorization mechanisms").
- All configured claims must be satisfied (AND across keys, OR within a key's allowed values); supports both plain string claims and array claims (e.g. `groups`). Empty/absent map keeps current behavior (any authenticated user is authorized).
- On failure, no session is created and the user is redirected to `/login?error=access_denied`, which now shows a short message in the UI.
- Per-tenant/per-namespace claim scoping (phase 2 of the issue) is out of scope here — there's no runtime "tenant" concept in Go today (tenants are a Helm/RBAC construct only), so it needs its own design.

Note: three comments on #904 discuss an unrelated connection-pool/timeout topic that doesn't match the issue body — treated as noise, not addressed here.

## Test plan
- [x] `go build ./...`, `go vet ./...`
- [x] `go test ./internal/server/... ./internal/burrito/config/...` (new table-driven tests for the claim-matching logic)
- [x] `helm lint deploy/charts/burrito` and `helm template deploy/charts/burrito` with `requiredClaims` set, confirming it flows through to the rendered config
- [x] `pnpm run lint`, `pnpm run build`, `pnpm run format-check` in `ui/`
- [ ] Manual end-to-end check against a real OIDC provider (not exercised here, no provider available in this environment)

Closes #904 (phase 1).

🤖 Generated with [Claude Code](https://claude.com/claude-code)