### PR TITLE
feat: configurable log format for controller and datastore

### DIFF
--- a/cmd/controllers/start.go
+++ b/cmd/controllers/start.go
@@ -46,5 +46,6 @@ func buildControllersStartCmd(app *burrito.App) *cobra.Command {
 	cmd.Flags().StringVar(&app.Config.Controller.HealthProbeBindAddress, "health-probe-bind-address", ":8081", "address to bind the metrics server embedded in the controllers")
 	cmd.Flags().StringVar(&app.Config.Controller.MetricsBindAddress, "metrics-bind-address", ":8080", "address to bind the health probe server embedded in the controllers")
 	cmd.Flags().IntVar(&app.Config.Controller.KubernetesWebhookPort, "kubernetes-webhook-port", 9443, "port used by the validating webhook server embedded in the controllers")
+	cmd.Flags().StringVar(&app.Config.Controller.LogFormat, "log-format", "text", "log format for controller logs, either \"text\" or \"json\"")
 	return cmd
 }

--- a/cmd/datastore/start.go
+++ b/cmd/datastore/start.go
@@ -19,5 +19,6 @@ func buildDatastoreStartCmd(app *burrito.App) *cobra.Command {
 		},
 	}
 	cmd.Flags().StringVar(&app.Config.Server.Addr, "addr", ":8080", "addr the datastore listens on")
+	cmd.Flags().StringVar(&app.Config.Datastore.LogFormat, "log-format", "text", "log format for the datastore, either \"text\" or \"json\"")
 	return cmd
 }

--- a/deploy/charts/burrito/README.md
+++ b/deploy/charts/burrito/README.md
@@ -19,6 +19,7 @@ A Helm chart for handling a complete burrito deployment
 | config.burrito.controller.kubernetesWebhookPort | int | `9443` | Port used to handle the Kubernetes webhook |
 | config.burrito.controller.leaderElection.enabled | bool | `true` | Enable/Disable leader election |
 | config.burrito.controller.leaderElection.id | string | `"6d185457.terraform.padok.cloud"` | Leader election lock name |
+| config.burrito.controller.logFormat | string | `"text"` | Log format for the controller, either "text" or "json" |
 | config.burrito.controller.maxConcurrentReconciles | int | `1` | Maximum number of concurrent reconciles for the controller, increse this value if you have a lot of resources to reconcile |
 | config.burrito.controller.metricsBindAddress | string | `":8080"` | Adress to bind the controller metrics |
 | config.burrito.controller.namespaces | list | `[]` | By default, the controller will only watch the tenants namespaces |

--- a/deploy/charts/burrito/README.md
+++ b/deploy/charts/burrito/README.md
@@ -30,6 +30,7 @@ A Helm chart for handling a complete burrito deployment
 | config.burrito.controller.timers.waitAction | string | `"1m"` | Duration to wait before retrying on locked layer |
 | config.burrito.controller.types | list | `["layer","repository","run","pullrequest"]` | Resource types to watch for reconciliation |
 | config.burrito.datastore.addr | string | `":8080"` | Datastore exposed port |
+| config.burrito.datastore.logFormat | string | `"text"` | Log format for the datastore, either "text" or "json" |
 | config.burrito.datastore.serviceAccounts | list | `[]` | Service account to use for datastore operations (e.g. reading/writing to storage) |
 | config.burrito.datastore.storage.azure.container | string | `""` | Azure storage container name |
 | config.burrito.datastore.storage.azure.storageAccount | string | `""` | Azure storage account name |

--- a/deploy/charts/burrito/values.yaml
+++ b/deploy/charts/burrito/values.yaml
@@ -49,6 +49,8 @@ config:
     # -- Provider cache custom configuration
     hermitcrab: {}
     datastore:
+      # -- Log format for the datastore, either "text" or "json"
+      logFormat: text
       # -- Service accounts that are allowed to access the datastore API in namespace/name format (not the service account used by the datastore pods, check datastore.serviceAccount.metadata for that)
       serviceAccounts: []
       storage:

--- a/deploy/charts/burrito/values.yaml
+++ b/deploy/charts/burrito/values.yaml
@@ -44,6 +44,8 @@ config:
       healthProbeBindAddress: ":8081"
       # -- Port used to handle the Kubernetes webhook
       kubernetesWebhookPort: 9443
+      # -- Log format for the controller, either "text" or "json"
+      logFormat: text
     # -- Provider cache custom configuration
     hermitcrab: {}
     datastore:

--- a/docs/operator-manual/advanced-configuration.md
+++ b/docs/operator-manual/advanced-configuration.md
@@ -21,6 +21,7 @@ They can be set in the Helm chart [values](https://github.com/padok-team/burrito
 |   `BURRITO_CONTROLLER_KUBERNETESWEBHOOKPORT`   |   port used by the validating webhook server embedded in the controllers    |               `9443`               |
 |   `BURRITO_CONTROLLER_MAXCONCURRENTRECONCILES` |    number of parallel resource reconciliation performed by the contoller    |                `0`                 |
 |   `BURRITO_CONTROLLER_MAXCONCURRENTRUNNERPODS` | maximum number for pods that run in parallel to perform plan/apply (0=inf)  |                `0`                 |
+|          `BURRITO_CONTROLLER_LOGFORMAT`        |            log format for the controller, either `text` or `json`          |               `text`               |
 
 ## Server's configuration
 

--- a/docs/operator-manual/advanced-configuration.md
+++ b/docs/operator-manual/advanced-configuration.md
@@ -21,7 +21,13 @@ They can be set in the Helm chart [values](https://github.com/padok-team/burrito
 |   `BURRITO_CONTROLLER_KUBERNETESWEBHOOKPORT`   |   port used by the validating webhook server embedded in the controllers    |               `9443`               |
 |   `BURRITO_CONTROLLER_MAXCONCURRENTRECONCILES` |    number of parallel resource reconciliation performed by the contoller    |                `0`                 |
 |   `BURRITO_CONTROLLER_MAXCONCURRENTRUNNERPODS` | maximum number for pods that run in parallel to perform plan/apply (0=inf)  |                `0`                 |
-|          `BURRITO_CONTROLLER_LOGFORMAT`        |            log format for the controller, either `text` or `json`          |               `text`               |
+|        `BURRITO_CONTROLLER_LOGFORMAT`          |           log format for the controller, either `text` or `json`            |               `text`               |
+
+## Datastore's configuration
+
+|      Environment variable       |                      Description                      | Default |
+| :-----------------------------: | :---------------------------------------------------: | :-----: |
+|  `BURRITO_DATASTORE_LOGFORMAT`  | log format for the datastore, either `text` or `json` | `text`  |
 
 ## Server's configuration
 

--- a/internal/burrito/config/config.go
+++ b/internal/burrito/config/config.go
@@ -68,6 +68,7 @@ type ControllerConfig struct {
 	RunParallelism          int                         `mapstructure:"runParallelism"`
 	MaxConcurrentReconciles int                         `mapstructure:"maxConcurrentReconciles"`
 	MaxConcurrentRunnerPods int                         `mapstructure:"maxConcurrentRunnerPods"`
+	LogFormat               string                      `mapstructure:"logFormat"`
 }
 
 type LeaderElectionConfig struct {

--- a/internal/burrito/config/config.go
+++ b/internal/burrito/config/config.go
@@ -27,6 +27,7 @@ type DatastoreConfig struct {
 	CertificateSecretName     string        `mapstructure:"certificateSecretName"`
 	Storage                   StorageConfig `mapstructure:"storage"`
 	AuthorizedServiceAccounts []string      `mapstructure:"serviceAccounts"`
+	LogFormat                 string        `mapstructure:"logFormat"`
 }
 
 type StorageConfig struct {

--- a/internal/burrito/config/config_test.go
+++ b/internal/burrito/config/config_test.go
@@ -81,6 +81,7 @@ func TestConfig_FromYamlFile(t *testing.T) {
 			MetricsBindAddress:     ":8080",
 			HealthProbeBindAddress: ":8081",
 			KubernetesWebhookPort:  9443,
+			LogFormat:              "text",
 		},
 		Server: config.ServerConfig{
 			Addr: ":9090",
@@ -136,6 +137,7 @@ func TestConfig_EnvVarOverrides(t *testing.T) {
 	setEnvVar(t, "BURRITO_CONTROLLER_MAXCONCURRENTRUNNERPODS", "10", &envVarList)
 	setEnvVar(t, "BURRITO_CONTROLLER_TERRAFORMMAXRETRIES", "32", &envVarList)
 	setEnvVar(t, "BURRITO_CONTROLLER_LEADERELECTION_ID", "other-leader-id", &envVarList)
+	setEnvVar(t, "BURRITO_CONTROLLER_LOGFORMAT", "json", &envVarList)
 	// Server
 	setEnvVar(t, "BURRITO_SERVER_ADDR", ":8090", &envVarList)
 
@@ -200,6 +202,7 @@ func TestConfig_EnvVarOverrides(t *testing.T) {
 			MetricsBindAddress:     ":8080",
 			HealthProbeBindAddress: ":8081",
 			KubernetesWebhookPort:  9443,
+			LogFormat:              "json",
 		},
 		Server: config.ServerConfig{
 			Addr: ":8090",

--- a/internal/burrito/config/config_test.go
+++ b/internal/burrito/config/config_test.go
@@ -83,6 +83,9 @@ func TestConfig_FromYamlFile(t *testing.T) {
 			KubernetesWebhookPort:  9443,
 			LogFormat:              "text",
 		},
+		Datastore: config.DatastoreConfig{
+			LogFormat: "text",
+		},
 		Server: config.ServerConfig{
 			Addr: ":9090",
 		},
@@ -138,6 +141,8 @@ func TestConfig_EnvVarOverrides(t *testing.T) {
 	setEnvVar(t, "BURRITO_CONTROLLER_TERRAFORMMAXRETRIES", "32", &envVarList)
 	setEnvVar(t, "BURRITO_CONTROLLER_LEADERELECTION_ID", "other-leader-id", &envVarList)
 	setEnvVar(t, "BURRITO_CONTROLLER_LOGFORMAT", "json", &envVarList)
+	// Datastore
+	setEnvVar(t, "BURRITO_DATASTORE_LOGFORMAT", "json", &envVarList)
 	// Server
 	setEnvVar(t, "BURRITO_SERVER_ADDR", ":8090", &envVarList)
 
@@ -203,6 +208,9 @@ func TestConfig_EnvVarOverrides(t *testing.T) {
 			HealthProbeBindAddress: ":8081",
 			KubernetesWebhookPort:  9443,
 			LogFormat:              "json",
+		},
+		Datastore: config.DatastoreConfig{
+			LogFormat: "json",
 		},
 		Server: config.ServerConfig{
 			Addr: ":8090",

--- a/internal/burrito/config/testdata/test-config-1.yaml
+++ b/internal/burrito/config/testdata/test-config-1.yaml
@@ -35,6 +35,7 @@ controller:
   metricsBindAddress: ":8080"
   healthProbeBindAddress: ":8081"
   kubernetesWebhookPort: 9443
+  logFormat: text
 
 server:
   addr: ":9090"

--- a/internal/burrito/config/testdata/test-config-1.yaml
+++ b/internal/burrito/config/testdata/test-config-1.yaml
@@ -37,5 +37,8 @@ controller:
   kubernetesWebhookPort: 9443
   logFormat: text
 
+datastore:
+  logFormat: text
+
 server:
   addr: ":9090"

--- a/internal/controllers/manager.go
+++ b/internal/controllers/manager.go
@@ -76,9 +76,10 @@ func init() {
 }
 
 func (c *Controllers) Exec() {
+	log.SetFormatter(&log.JSONFormatter{})
 	ctrl.SetLogger(logrusr.New(&log.Logger{
 		Out:       os.Stderr,
-		Formatter: new(logrus.TextFormatter),
+		Formatter: new(logrus.JSONFormatter),
 		Hooks:     make(logrus.LevelHooks),
 		Level:     logrus.DebugLevel,
 	}))

--- a/internal/controllers/manager.go
+++ b/internal/controllers/manager.go
@@ -76,10 +76,14 @@ func init() {
 }
 
 func (c *Controllers) Exec() {
-	log.SetFormatter(&log.JSONFormatter{})
+	var formatter logrus.Formatter = &logrus.TextFormatter{}
+	if c.config.Controller.LogFormat == "json" {
+		formatter = &logrus.JSONFormatter{}
+	}
+	log.SetFormatter(formatter)
 	ctrl.SetLogger(logrusr.New(&log.Logger{
 		Out:       os.Stderr,
-		Formatter: new(logrus.JSONFormatter),
+		Formatter: formatter,
 		Hooks:     make(logrus.LevelHooks),
 		Level:     logrus.DebugLevel,
 	}))

--- a/internal/datastore/datastore.go
+++ b/internal/datastore/datastore.go
@@ -30,6 +30,7 @@ func New(c *config.Config) *Datastore {
 }
 
 func (s *Datastore) Exec() {
+	log.SetFormatter(&log.JSONFormatter{})
 	s.API = api.New(s.Config)
 	s.API.Storage = storage.New(*s.Config)
 	authz := authz.NewAuthz()

--- a/internal/datastore/datastore.go
+++ b/internal/datastore/datastore.go
@@ -30,7 +30,9 @@ func New(c *config.Config) *Datastore {
 }
 
 func (s *Datastore) Exec() {
-	log.SetFormatter(&log.JSONFormatter{})
+	if s.Config.Datastore.LogFormat == "json" {
+		log.SetFormatter(&log.JSONFormatter{})
+	}
 	s.API = api.New(s.Config)
 	s.API.Storage = storage.New(*s.Config)
 	authz := authz.NewAuthz()


### PR DESCRIPTION
Clean rebase of #800 onto current `main` (the original branch was 70+ commits behind and conflicting), with the datastore log format made opt-in.

Credit to @seboudry for the original change and to @corrieriluca for the controller log-format toggle — both commits are preserved as-is; only the datastore behaviour was changed on top.

### What changed relative to #800

`internal/datastore/datastore.go` forced `log.JSONFormatter` unconditionally. The datastore's HTTP access logs are uniform (`getLoggerConfig` → `log.WithFields(...)`), but the component also emits a dozen non-HTTP logrus lines that would have switched format without any opt-out:

- `internal/datastore/api/encrypt.go` (7 call sites)
- `internal/datastore/storage/common.go:76,91`
- `datastore.go` startup message

So the datastore now gets the same switch as the controller, defaulting to `text`:

| Component  | Default   | Setting                                                      |
| ---------- | --------- | ------------------------------------------------------------ |
| Controller | `text`    | `controller.logFormat` / `BURRITO_CONTROLLER_LOGFORMAT`       |
| Datastore  | `text`    | `datastore.logFormat` / `BURRITO_DATASTORE_LOGFORMAT`         |
| Server     | `json`    | unchanged (hardcoded on `main` before this PR)                |

No default output format changes for any component → no breaking change for existing log pipelines.

### Known limitations (not addressed here)

- **The runner is untouched**, so #799 is not fully covered. Runner logs are streamed to the datastore and rendered in the dashboard log viewer, so switching them to JSON needs its own look.
- **`e.Logger.Fatal(...)`** in `datastore.go` uses Echo's gommon logger, which `log.SetFormatter` does not reach — that one line stays plain text even in `json` mode.
- **`--log-format` is overridden by the config file**, like every other flag in this repo (`TestConfig_FlagOverrides` is commented out on `main` with a `// TODO: make that test pass`). Since the Helm ConfigMap always renders `logFormat`, the working knobs on a chart deployment are the Helm value and the environment variable.
- An invalid value (e.g. `JSON`) silently falls back to `text`, which is the safe direction.

### Verification

- `go build ./...`, `go vet`, `go test ./internal/burrito/config/...` pass
- `helm template` renders `controller.logFormat` and `datastore.logFormat` in the ConfigMap
- config tests cover both the file and the `BURRITO_*_LOGFORMAT` env var paths

refs #799
Supersedes #800.
