### PR TITLE
fix(controller): requeue a failed run when its grace period ends

### DIFF
--- a/internal/controllers/terraformrun/states.go
+++ b/internal/controllers/terraformrun/states.go
@@ -135,10 +135,11 @@ func (s *FailureGracePeriod) getHandler() Handler {
 		endIdleTime := lastActionTime.Add(expTime)
 		now := r.Clock.Now()
 		if endIdleTime.After(now) {
-			log.Infof("the grace period is over for run %v, new retry", run.Name)
-			return ctrl.Result{RequeueAfter: r.Config.Controller.Timers.WaitAction}, getRunInfo(run)
+			log.Infof("the grace period is still running for run %v, waiting until %v", run.Name, endIdleTime)
+			return ctrl.Result{RequeueAfter: endIdleTime.Sub(now)}, getRunInfo(run)
 		}
-		return ctrl.Result{RequeueAfter: now.Sub(endIdleTime)}, getRunInfo(run)
+		log.Infof("the grace period is over for run %v, new retry", run.Name)
+		return ctrl.Result{RequeueAfter: r.Config.Controller.Timers.WaitAction}, getRunInfo(run)
 	}
 }
 

--- a/internal/controllers/terraformrun/states_test.go
+++ b/internal/controllers/terraformrun/states_test.go
@@ -1,0 +1,88 @@
+package terraformrun
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	configv1alpha1 "github.com/padok-team/burrito/api/v1alpha1"
+	"github.com/padok-team/burrito/internal/burrito/config"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+const stateTestTime = "Mon May  8 11:21:53 UTC 2023"
+
+type fixedClock struct {
+	now time.Time
+}
+
+func (c fixedClock) Now() time.Time {
+	return c.now
+}
+
+func failedRun(lastRun time.Time) *configv1alpha1.TerraformRun {
+	return &configv1alpha1.TerraformRun{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "run",
+			Namespace: "default",
+		},
+		Status: configv1alpha1.TerraformRunStatus{
+			State:     "FailureGracePeriod",
+			LastRun:   lastRun.Format(time.UnixDate),
+			RunnerPod: "runner-pod",
+		},
+	}
+}
+
+func stateTestNow(t *testing.T) time.Time {
+	t.Helper()
+	now, err := time.Parse(time.UnixDate, stateTestTime)
+	if err != nil {
+		t.Fatalf("could not parse test time: %s", err)
+	}
+	return now
+}
+
+func TestFailureGracePeriodRequeuesWhenTheGracePeriodEnds(t *testing.T) {
+	now := stateTestNow(t)
+	cfg := config.TestConfig()
+	// The runner pod failed 5 seconds ago and the grace period is 15 seconds,
+	// so the run must be requeued 10 seconds from now.
+	run := failedRun(now.Add(-5 * time.Second))
+	r := &Reconciler{Config: cfg, Clock: fixedClock{now: now}}
+
+	result, _ := (&FailureGracePeriod{}).getHandler()(context.Background(), r, run, nil, nil)
+
+	if result.RequeueAfter != 10*time.Second {
+		t.Fatalf("expected the run to be requeued in 10s, when the grace period ends, got %s", result.RequeueAfter)
+	}
+}
+
+func TestFailureGracePeriodRequeuesWithWaitActionOnceTheGracePeriodIsOver(t *testing.T) {
+	now := stateTestNow(t)
+	cfg := config.TestConfig()
+	// The runner pod failed 60 seconds ago and the grace period is 15 seconds,
+	// so it is over and the run must be requeued for a retry.
+	run := failedRun(now.Add(-60 * time.Second))
+	r := &Reconciler{Config: cfg, Clock: fixedClock{now: now}}
+
+	result, _ := (&FailureGracePeriod{}).getHandler()(context.Background(), r, run, nil, nil)
+
+	if result.RequeueAfter != cfg.Controller.Timers.WaitAction {
+		t.Fatalf("expected the run to be requeued after %s, got %s", cfg.Controller.Timers.WaitAction, result.RequeueAfter)
+	}
+}
+
+func TestFailureGracePeriodRequeuesOnErrorWhenLastRunIsNotParsable(t *testing.T) {
+	now := stateTestNow(t)
+	cfg := config.TestConfig()
+	run := failedRun(now)
+	run.Status.LastRun = "not a date"
+	r := &Reconciler{Config: cfg, Clock: fixedClock{now: now}}
+
+	result, _ := (&FailureGracePeriod{}).getHandler()(context.Background(), r, run, nil, nil)
+
+	if result.RequeueAfter != cfg.Controller.Timers.OnError {
+		t.Fatalf("expected the run to be requeued after %s, got %s", cfg.Controller.Timers.OnError, result.RequeueAfter)
+	}
+}


### PR DESCRIPTION
## What

`GetState` only routes a run to the `FailureGracePeriod` handler while `IsInFailureGracePeriod` is true, and `internal/controllers/terraformrun/conditions.go:149` makes that condition true exactly when `lastActionTime + backoff` is still in the future. The handler at `internal/controllers/terraformrun/states.go:137` re-tests the same thing and then acts on it backwards.

So `endIdleTime.After(now)` is the branch that always runs. It logs `the grace period is over for run %v, new retry` while the grace period is still running, and requeues after `Timers.WaitAction`. The branch below it is unreachable, and its `now.Sub(endIdleTime)` is the time since the grace period ended rather than the time left until it ends.

The exponential backoff therefore never drives the requeue. A failed run is re-reconciled every `waitAction` until the backoff expires, each pass writing the wrong log line, and the retry fires up to one `waitAction` late. With the chart defaults in `deploy/charts/burrito/values.yaml` (`failureGracePeriod: 15s`, `waitAction: 10s`) three failed attempts mean about thirty pointless reconciles. With the built-in `waitAction` default of `5m` in `internal/burrito/config/config.go` the first retry waits five minutes instead of fifteen seconds.

## Fix

Swap the two branches. While the grace period is running the handler requeues after `endIdleTime.Sub(now)`, so the controller wakes exactly when the backoff expires. `Timers.WaitAction` and the `grace period is over` message move to the case where it has already elapsed. That lines up with the sibling condition in `conditions.go`, which already distinguishes `still active (until %s)` from `over (since %s)`, and with what the docs promise for `failureGracePeriod`: a grace period before retrying on failure that increases exponentially with the number of failed retries.

## Testing

`internal/controllers/terraformrun/states_test.go` drives the handler with a fixed clock and `config.TestConfig()`, covering both branches plus the unparsable `Status.LastRun` path.

On `main` with only the test file applied:

```
$ go test -run 'TestFailureGracePeriod' ./internal/controllers/terraformrun/
--- FAIL: TestFailureGracePeriodRequeuesWhenTheGracePeriodEnds (0.00s)
    states_test.go:57: expected the run to be requeued in 10s, when the grace period ends, got 5m0s
--- FAIL: TestFailureGracePeriodRequeuesWithWaitActionOnceTheGracePeriodIsOver (0.00s)
    states_test.go:72: expected the run to be requeued after 5m0s, got 45s
FAIL	github.com/padok-team/burrito/internal/controllers/terraformrun	1.031s
```

With the fix, together with the package's other unit tests:

```
$ go test -run 'TestFailureGracePeriod|TestGetMaxRetries|TestGetRunExponentialBackOffTime' ./internal/controllers/terraformrun/
ok  	github.com/padok-team/burrito/internal/controllers/terraformrun	0.875s
```

`gofmt -l internal/controllers/terraformrun/` and `go vet ./internal/controllers/terraformrun/` are clean. `golangci-lint run ./internal/controllers/terraformrun/...`, at the 2.13.2 pinned in `mise.toml`, reports the same seven issues on `main` and on this branch (one errcheck, six staticcheck QF1008), none of them on a changed line.
