### PR TITLE
fix(controller): unlock layer when the locking runner is gone

### DIFF
--- a/internal/controllers/terraformlayer/controller.go
+++ b/internal/controllers/terraformlayer/controller.go
@@ -26,6 +26,7 @@ import (
 	"github.com/padok-team/burrito/internal/controllers/metrics"
 	datastore "github.com/padok-team/burrito/internal/datastore/client"
 	"github.com/padok-team/burrito/internal/lock"
+	coordination "k8s.io/api/coordination/v1"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -89,8 +90,17 @@ func (r *Reconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Resu
 		return ctrl.Result{RequeueAfter: r.Config.Controller.Timers.OnError}, err
 	}
 	if locked {
-		log.Infof("TerraformLayer %s is locked, skipping reconciliation.", layer.Name)
-		return ctrl.Result{RequeueAfter: r.Config.Controller.Timers.WaitAction}, nil
+		released, err := r.releaseOrphanedLayerLock(ctx, layer)
+		if err != nil {
+			log.Errorf("failed to check or release the layer lock: %s", err)
+			return ctrl.Result{RequeueAfter: r.Config.Controller.Timers.OnError}, err
+		}
+		if !released {
+			log.Infof("TerraformLayer %s is locked, skipping reconciliation.", layer.Name)
+			return ctrl.Result{RequeueAfter: r.Config.Controller.Timers.WaitAction}, nil
+		}
+		r.Recorder.Event(layer, corev1.EventTypeNormal, "Reconciliation", "Released orphaned layer lock: the runner holding the lock does not exist anymore")
+		log.Infof("TerraformLayer %s was locked by a non-existent runner, releasing the lock and continuing reconciliation", layer.Name)
 	}
 	repository := &configv1alpha1.TerraformRepository{}
 	log.Infof("getting Linked TerraformRepository to layer %s", layer.Name)
@@ -143,6 +153,58 @@ func (r *Reconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Resu
 
 	log.Infof("finished reconciliation cycle for layer %s/%s", layer.Namespace, layer.Name)
 	return result, nil
+}
+
+// releaseOrphanedLayerLock releases the layer lock when it is held by a run
+// whose runner pod no longer exists, or whose run has been deleted. Such a
+// lock can never be released by the run state machine: it only removes the
+// lock on success or failure, both of which depend on the missing pod.
+// Returns true when the orphaned lock was released.
+func (r *Reconciler) releaseOrphanedLayerLock(ctx context.Context, layer *configv1alpha1.TerraformLayer) (bool, error) {
+	lease, err := lock.GetLock(ctx, r.Client, layer)
+	if err != nil {
+		return false, err
+	}
+	if lease == nil {
+		return false, nil
+	}
+	runName := ""
+	for _, owner := range lease.OwnerReferences {
+		if owner.Kind == "TerraformRun" {
+			runName = owner.Name
+			break
+		}
+	}
+	if runName == "" {
+		return false, nil
+	}
+	run := &configv1alpha1.TerraformRun{}
+	err = r.Client.Get(ctx, types.NamespacedName{Namespace: layer.Namespace, Name: runName}, run)
+	if errors.IsNotFound(err) {
+		return r.deleteOrphanedLayerLock(ctx, lease)
+	}
+	if err != nil {
+		return false, err
+	}
+	if run.Status.RunnerPod == "" {
+		return false, nil
+	}
+	pod := &corev1.Pod{}
+	err = r.Client.Get(ctx, types.NamespacedName{Namespace: layer.Namespace, Name: run.Status.RunnerPod}, pod)
+	if errors.IsNotFound(err) {
+		return r.deleteOrphanedLayerLock(ctx, lease)
+	}
+	if err != nil {
+		return false, err
+	}
+	return false, nil
+}
+
+func (r *Reconciler) deleteOrphanedLayerLock(ctx context.Context, lease *coordination.Lease) (bool, error) {
+	if err := r.Client.Delete(ctx, lease); err != nil && !errors.IsNotFound(err) {
+		return false, err
+	}
+	return true, nil
 }
 
 func (r *Reconciler) cleanupRuns(ctx context.Context, layer *configv1alpha1.TerraformLayer, repository *configv1alpha1.TerraformRepository) error {

--- a/internal/controllers/terraformlayer/controller_test.go
+++ b/internal/controllers/terraformlayer/controller_test.go
@@ -598,6 +598,85 @@ var _ = Describe("Layer", func() {
 			})
 		})
 	})
+	Describe("Orphaned lock cases", func() {
+		lockLayer := func(layerName, runName string) {
+			layer := &configv1alpha1.TerraformLayer{}
+			Expect(k8sClient.Get(context.TODO(), types.NamespacedName{Namespace: "default", Name: layerName}, layer)).NotTo(HaveOccurred())
+			run := &configv1alpha1.TerraformRun{}
+			Expect(k8sClient.Get(context.TODO(), types.NamespacedName{Namespace: "default", Name: runName}, run)).NotTo(HaveOccurred())
+			Expect(lock.CreateLock(context.TODO(), k8sClient, layer, run)).NotTo(HaveOccurred())
+		}
+		Describe("When a TerraformLayer is locked by a run whose runner pod no longer exists", Ordered, func() {
+			BeforeAll(func() {
+				lockLayer("orphan-lock-case-1", "orphan-lock-run")
+				name = types.NamespacedName{
+					Name:      "orphan-lock-case-1",
+					Namespace: "default",
+				}
+				result, layer, reconcileError, err = getResult(name, reconciler)
+			})
+			It("should still exists", func() {
+				Expect(err).NotTo(HaveOccurred())
+			})
+			It("should not return an error", func() {
+				Expect(reconcileError).NotTo(HaveOccurred())
+			})
+			It("should have released the orphaned lock", func() {
+				Expect(lock.IsLayerLocked(context.TODO(), k8sClient, layer)).To(BeFalse())
+			})
+			It("should continue reconciliation and end in PlanNeeded state", func() {
+				Expect(layer.Status.State).To(Equal("PlanNeeded"))
+			})
+			It("should have created a plan TerraformRun", func() {
+				runs, err := getLinkedRuns(k8sClient, layer)
+				Expect(err).NotTo(HaveOccurred())
+				Expect(len(runs.Items)).To(Equal(1))
+				Expect(runs.Items[0].Spec.Action).To(Equal("plan"))
+			})
+		})
+		Describe("When a TerraformLayer is locked by a run whose runner pod is still running", Ordered, func() {
+			BeforeAll(func() {
+				err := k8sClient.Create(context.TODO(), &corev1.Pod{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "orphan-lock-pod-alive",
+						Namespace: "default",
+					},
+					Spec: corev1.PodSpec{
+						Containers: []corev1.Container{
+							{Name: "runner", Image: "burrito-runner:test"},
+						},
+					},
+				})
+				Expect(err).NotTo(HaveOccurred())
+				lockLayer("orphan-lock-case-2", "orphan-lock-run-alive")
+				name = types.NamespacedName{
+					Name:      "orphan-lock-case-2",
+					Namespace: "default",
+				}
+				result, layer, reconcileError, err = getResult(name, reconciler)
+			})
+			It("should still exists", func() {
+				Expect(err).NotTo(HaveOccurred())
+			})
+			It("should not return an error", func() {
+				Expect(reconcileError).NotTo(HaveOccurred())
+			})
+			It("should stay locked", func() {
+				Expect(lock.IsLayerLocked(context.TODO(), k8sClient, layer)).To(BeTrue())
+			})
+			It("should not update status", func() {
+				Expect(layer.Status.State).To(Equal(""))
+			})
+			It("should set RequeueAfter to WaitAction", func() {
+				Expect(result.RequeueAfter).To(Equal(reconciler.Config.Controller.Timers.WaitAction))
+			})
+			It("should not have created any TerraformRun", func() {
+				runs, err := getLinkedRuns(k8sClient, layer)
+				Expect(err).NotTo(HaveOccurred())
+				Expect(len(runs.Items)).To(Equal(0))
+			})
+		})
+	})
 	Describe("Retry limit cases", func() {
 		Describe("When a TerraformLayer last plan run has reached the retry limit for the same revision", Ordered, func() {
 			BeforeAll(func() {

--- a/internal/controllers/terraformlayer/testdata/orphan-lock-case.yaml
+++ b/internal/controllers/terraformlayer/testdata/orphan-lock-case.yaml
@@ -1,0 +1,77 @@
+apiVersion: config.terraform.padok.cloud/v1alpha1
+kind: TerraformLayer
+metadata:
+  labels:
+    app.kubernetes.io/instance: in-cluster-burrito
+  name: orphan-lock-case-1
+  namespace: default
+  annotations:
+    runner.terraform.padok.cloud/plan-commit: ca9b6c80ac8fb5cd837ae9b374b79ff33f472558
+    runner.terraform.padok.cloud/plan-date: Mon May  8 10:21:53 UTC 2023
+    runner.terraform.padok.cloud/plan-run: run-succeeded/0
+    runner.terraform.padok.cloud/plan-sum: AuP6pMNxWsbSZKnxZvxD842wy0qaF9JCX8HW1nFeL1I=
+    webhook.terraform.padok.cloud/branch-commit: cb9f15b90861c8c4364cdde63d17837c7a9ccca9
+spec:
+  branch: main
+  path: orphan-lock/
+  remediationStrategy:
+    autoApply: true
+  repository:
+    name: burrito
+    namespace: default
+  terraform:
+    enabled: true
+    version: 1.3.1
+  terragrunt:
+    enabled: true
+    version: 0.45.4
+---
+apiVersion: config.terraform.padok.cloud/v1alpha1
+kind: TerraformRun
+metadata:
+  name: orphan-lock-run
+  namespace: default
+spec:
+  action: plan
+  layer:
+    name: orphan-lock-case-1
+    namespace: default
+status:
+  runnerPod: orphan-lock-pod
+---
+apiVersion: config.terraform.padok.cloud/v1alpha1
+kind: TerraformLayer
+metadata:
+  labels:
+    app.kubernetes.io/instance: in-cluster-burrito
+  name: orphan-lock-case-2
+  namespace: default
+  annotations:
+    webhook.terraform.padok.cloud/branch-commit: cb9f15b90861c8c4364cdde63d17837c7a9ccca9
+spec:
+  branch: main
+  path: orphan-lock-alive/
+  remediationStrategy:
+    autoApply: true
+  repository:
+    name: burrito
+    namespace: default
+  terraform:
+    enabled: true
+    version: 1.3.1
+  terragrunt:
+    enabled: true
+    version: 0.45.4
+---
+apiVersion: config.terraform.padok.cloud/v1alpha1
+kind: TerraformRun
+metadata:
+  name: orphan-lock-run-alive
+  namespace: default
+spec:
+  action: plan
+  layer:
+    name: orphan-lock-case-2
+    namespace: default
+status:
+  runnerPod: orphan-lock-pod-alive

--- a/internal/lock/lock.go
+++ b/internal/lock/lock.go
@@ -47,17 +47,28 @@ func getLeaseLock(layer *configv1alpha1.TerraformLayer, run *configv1alpha1.Terr
 }
 
 func IsLayerLocked(ctx context.Context, c client.Client, layer *configv1alpha1.TerraformLayer) (bool, error) {
-	err := c.Get(ctx, types.NamespacedName{
-		Name:      getLeaseName(layer),
-		Namespace: layer.Namespace,
-	}, &coordination.Lease{})
-	if errors.IsNotFound(err) {
-		return false, nil
-	}
+	lease, err := GetLock(ctx, c, layer)
 	if err != nil {
 		return false, err
 	}
-	return true, nil
+	return lease != nil, nil
+}
+
+// GetLock returns the Lease holding the lock on the given layer, or nil when
+// the layer is not locked.
+func GetLock(ctx context.Context, c client.Client, layer *configv1alpha1.TerraformLayer) (*coordination.Lease, error) {
+	lease := &coordination.Lease{}
+	err := c.Get(ctx, types.NamespacedName{
+		Name:      getLeaseName(layer),
+		Namespace: layer.Namespace,
+	}, lease)
+	if errors.IsNotFound(err) {
+		return nil, nil
+	}
+	if err != nil {
+		return nil, err
+	}
+	return lease, nil
 }
 
 func CreateLock(ctx context.Context, c client.Client, layer *configv1alpha1.TerraformLayer, run *configv1alpha1.TerraformRun) error {
@@ -67,5 +78,11 @@ func CreateLock(ctx context.Context, c client.Client, layer *configv1alpha1.Terr
 
 func DeleteLock(ctx context.Context, c client.Client, layer *configv1alpha1.TerraformLayer, run *configv1alpha1.TerraformRun) error {
 	leaseLock := getLeaseLock(layer, run)
-	return c.Delete(ctx, leaseLock)
+	err := c.Delete(ctx, leaseLock)
+	if errors.IsNotFound(err) {
+		// The lock may already have been released (e.g. as an orphaned lock
+		// cleaned up by the layer controller): nothing left to do.
+		return nil
+	}
+	return err
 }

--- a/internal/lock/lock_test.go
+++ b/internal/lock/lock_test.go
@@ -100,6 +100,45 @@ var _ = Describe("Lock", func() {
 			Expect(locked).To(Equal(false))
 		})
 	})
+	Describe("GetLock and idempotent DeleteLock", Ordered, func() {
+		BeforeAll(func() {
+			layer = &configv1alpha1.TerraformLayer{}
+			getErrLayer = k8sClient.Get(context.TODO(), types.NamespacedName{
+				Namespace: "default",
+				Name:      "test",
+			}, layer)
+			run = &configv1alpha1.TerraformRun{}
+			getErrRun = k8sClient.Get(context.TODO(), types.NamespacedName{
+				Namespace: "default",
+				Name:      "test-run",
+			}, run)
+			Expect(getErrLayer).NotTo(HaveOccurred())
+			Expect(getErrRun).NotTo(HaveOccurred())
+		})
+		It("should return no lease when the layer is not locked", func() {
+			lease, err := lock.GetLock(context.TODO(), k8sClient, layer)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(lease).To(BeNil())
+		})
+		It("should not return an error when deleting a missing lease", func() {
+			err := lock.DeleteLock(context.TODO(), k8sClient, layer, run)
+			Expect(err).NotTo(HaveOccurred())
+		})
+		It("should return the lease when the layer is locked", func() {
+			err := lock.CreateLock(context.TODO(), k8sClient, layer, run)
+			Expect(err).NotTo(HaveOccurred())
+			lease, err := lock.GetLock(context.TODO(), k8sClient, layer)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(lease).NotTo(BeNil())
+			Expect(lease.OwnerReferences[0].Name).To(Equal("test-run"))
+		})
+		It("should not return an error when deleting the lease twice", func() {
+			err := lock.DeleteLock(context.TODO(), k8sClient, layer, run)
+			Expect(err).NotTo(HaveOccurred())
+			err = lock.DeleteLock(context.TODO(), k8sClient, layer, run)
+			Expect(err).NotTo(HaveOccurred())
+		})
+	})
 })
 
 var _ = AfterSuite(func() {


### PR DESCRIPTION
Closes #238

## Problem

A TerraformLayer lock is a `coordination.Lease` owned by a `TerraformRun`. When the runner pod is killed before the run reaches a terminal state (e.g. spot instance reclaim, node drain), the run state machine can never release the lock: it only deletes it on success or failure, both of which depend on the missing pod. Every subsequent run then fails while the layer stays locked forever.

## Fix

During reconciliation, when the layer is locked, the controller now checks whether the lock is orphaned:

- the `TerraformRun` owning the Lease no longer exists, or
- the runner pod referenced by `status.runnerPod` no longer exists.

In both cases the orphaned lock is released (with a normal event on the layer) and reconciliation continues, so the next plan/apply run can proceed.

Supporting changes:

- `lock.GetLock` exposes the layer Lease so the controller can inspect its owner.
- `lock.DeleteLock` tolerates a missing Lease, so run success/failure cleanups don't loop on errors when the lock was already released as orphaned.

## Verification

- New BDD cases in the TerraformLayer controller suite: locked-by-missing-runner releases the lock and proceeds (PlanNeeded + new plan run); locked-by-running-pod keeps the lock and skips.
- New lock suite cases: `GetLock` nil/lease behavior and idempotent `DeleteLock`.
- `go build ./...`, `go vet` on touched packages and the envtest suites (layer 144/144, run 72/72, lock 10/10) pass locally with Go 1.26.0.